### PR TITLE
JASSjr in Python

### DIFF
--- a/JASSjr_index.py
+++ b/JASSjr_index.py
@@ -15,9 +15,28 @@ doc_ids = []
 push_next = False
 vocab = defaultdict(lambda: array('i'))
 
+def lex(text):
+    current = 0
+    while True:
+        while current < len(text) and not text[current].isalnum() and text[current] != "<":
+            current += 1
+
+        start = current
+        if current < len(text) and text[current].isalnum():
+            while current < len(text) and text[current].isalnum() or text[current] == "-":
+                current += 1
+        elif current < len(text) and text[current] == "<":
+            current += 1
+            while current < len(text) and text[current-1] != ">":
+                current += 1
+        else:
+            break
+
+        yield text[start:current]
+
 with open(sys.argv[1], 'r') as file:
     for line in file:
-        for token in line.split():
+        for token in lex(line):
             if token == "<DOC>":
                 if docid != -1:
                     length_vector.append(document_length)

--- a/JASSjr_index.py
+++ b/JASSjr_index.py
@@ -10,7 +10,7 @@ if len(sys.argv) != 2:
 
 docid = -1
 document_length = 0
-length_vector = []
+length_vector = array('i')
 doc_ids = []
 push_next = False
 vocab = defaultdict(lambda: array('i'))
@@ -58,8 +58,7 @@ with open("docids.bin", "w") as file:
         file.write(f"{doc}\n")
 
 with open("lengths.bin", "wb") as file:
-    for length in length_vector:
-        file.write(struct.pack('i', length))
+    length_vector.tofile(file)
 
 postings_fp = open("postings.bin", "wb")
 vocab_fp = open("vocab.bin", "wb")
@@ -70,7 +69,7 @@ for term, postings in vocab.items():
 
     vocab_fp.write(struct.pack('B', len(term)))
     vocab_fp.write(term.encode())
-    vocab_fp.write(struct.pack('B', 0)) # null termination
+    vocab_fp.write(b'\0') # null termination
     vocab_fp.write(struct.pack('i', where))
     vocab_fp.write(struct.pack('i', len(postings) * 4)) # no. bytes
 

--- a/JASSjr_index.py
+++ b/JASSjr_index.py
@@ -20,7 +20,7 @@ length_vector = array('i') # hold the length of each document
 
 # A token is either an XML tag '<'..'>' or a sequence of alpha-numerics.
 # TREC <DOCNO> primary keys have a hyphen in them
-lexer = re.compile("[a-zA-Z0-9][a-zA-Z0-9-]*|<DOC>|<DOCNO>")
+lexer = re.compile("[a-zA-Z0-9][a-zA-Z0-9-]*|<[^>]*>")
 
 docid = -1
 document_length = 0
@@ -39,13 +39,14 @@ with open(sys.argv[1], 'r') as file:
                 document_length = 0
                 if docid % 1000 == 0:
                     print(f"{docid} documents indexed")
-                continue
             # if the last token we saw was a <DOCNO> then the next token is the primary key
             if push_next:
                 doc_ids.append(token)
                 push_next = False
             if token == "<DOCNO>":
                 push_next = True
+            # Don't index XML tags
+            if token[0] == "<":
                 continue
 
             # lower case the string

--- a/JASSjr_index.py
+++ b/JASSjr_index.py
@@ -15,7 +15,7 @@ length_vector = array('i')
 doc_ids = []
 push_next = False
 vocab = defaultdict(lambda: array('i'))
-lexer = re.compile("[a-zA-Z0-9][a-zA-Z0-9-]*|<[^>]*>")
+lexer = re.compile("[a-zA-Z0-9][a-zA-Z0-9-]*|<DOC>|<DOCNO>")
 
 with open(sys.argv[1], 'r') as file:
     for line in file:
@@ -27,12 +27,12 @@ with open(sys.argv[1], 'r') as file:
                 document_length = 0
                 if docid % 1000 == 0:
                     print(f"{docid} documents indexed")
+                continue
             if push_next:
                 doc_ids.append(token)
                 push_next = False
             if token == "<DOCNO>":
                 push_next = True
-            if token[0] == "<":
                 continue
 
             token = token.lower()

--- a/JASSjr_index.py
+++ b/JASSjr_index.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+from collections import defaultdict
+import struct
+import sys
+
+if len(sys.argv) != 2:
+    sys.exit(f"Usage: {sys.argv[0]} <infile.xml>")
+
+docid = -1
+document_length = 0
+length_vector = []
+doc_ids = []
+push_next = False
+vocab = defaultdict(lambda: [])
+
+with open(sys.argv[1], 'r') as file:
+    for line in file:
+        for token in line.split():
+            if token == "<DOC>":
+                if docid != -1:
+                    length_vector.append(document_length)
+                docid += 1
+                document_length = 0
+                if docid % 1000 == 0:
+                    print(f"{docid} documents indexed")
+            if push_next:
+                doc_ids.append(token)
+                push_next = False
+            if token == "<DOCNO>":
+                push_next = True
+            if token[0] == "<":
+                continue
+
+            token = token.lower()
+
+            token = token[0:255]
+
+            postings_list = vocab[token]
+            if len(postings_list) == 0 or postings_list[-1][0] != docid:
+                postings_list.append((docid, 1))
+            else:
+                pair = postings_list[-1]
+                postings_list[-1] = (docid, pair[1] + 1)
+
+            document_length += 1
+
+if docid == -1:
+    sys.exit()
+
+print(f"Indexed {docid + 1} documents. Serialising...")
+
+length_vector.append(document_length)
+
+with open("docids.bin", "w") as file:
+    for doc in doc_ids:
+        file.write(f"{doc}\n")
+
+with open("lengths.bin", "wb") as file:
+    for length in length_vector:
+        file.write(struct.pack('i', length))
+
+postings_fp = open("postings.bin", "wb")
+vocab_fp = open("vocab.bin", "wb")
+
+for term, postings in vocab.items():
+    where = postings_fp.tell()
+    for pair in postings:
+        postings_fp.write(struct.pack('ii', pair[0], pair[1]))
+
+    vocab_fp.write(struct.pack('B', len(term)))
+    vocab_fp.write(term.encode())
+    vocab_fp.write(struct.pack('B', 0)) # null termination
+    vocab_fp.write(struct.pack('i', where))
+    vocab_fp.write(struct.pack('i', len(postings) * 8))
+
+postings_fp.close()
+vocab_fp.close()

--- a/JASSjr_index.py
+++ b/JASSjr_index.py
@@ -1,33 +1,46 @@
 #!/usr/bin/env python3
 
+# JASSjr_index.py
+# Copyright (c) 2023 Vaughan Kitchen
+# Minimalistic BM25 search engine.
+
 from array import array
 from collections import defaultdict
 import re
 import struct
 import sys
 
+# Make sure we have one paramter, the filename
 if len(sys.argv) != 2:
     sys.exit(f"Usage: {sys.argv[0]} <infile.xml>")
 
+vocab = defaultdict(lambda: array('i')) # the in-memory index
+doc_ids = [] # the primary keys
+length_vector = array('i') # hold the length of each document
+
+# A token is either an XML tag '<'..'>' or a sequence of alpha-numerics.
+# TREC <DOCNO> primary keys have a hyphen in them
+lexer = re.compile("[a-zA-Z0-9][a-zA-Z0-9-]*|<DOC>|<DOCNO>")
+
 docid = -1
 document_length = 0
-length_vector = array('i')
-doc_ids = []
-push_next = False
-vocab = defaultdict(lambda: array('i'))
-lexer = re.compile("[a-zA-Z0-9][a-zA-Z0-9-]*|<DOC>|<DOCNO>")
+push_next = False # is the next token the primary key?
 
 with open(sys.argv[1], 'r') as file:
     for line in file:
         for token in lexer.findall(line):
+            # If we see a <DOC> tag then we're at the start of the next document
             if token == "<DOC>":
+                # Save the previous document length
                 if docid != -1:
                     length_vector.append(document_length)
+                # Move on to the next document
                 docid += 1
                 document_length = 0
                 if docid % 1000 == 0:
                     print(f"{docid} documents indexed")
                 continue
+            # if the last token we saw was a <DOCNO> then the next token is the primary key
             if push_next:
                 doc_ids.append(token)
                 push_next = False
@@ -35,10 +48,13 @@ with open(sys.argv[1], 'r') as file:
                 push_next = True
                 continue
 
+            # lower case the string
             token = token.lower()
 
+            # truncate any long tokens at 255 charactes (so that the length can be stored first and in a single byte)
             token = token[0:255]
 
+            # add the posting to the in-memory index
             postings_list = vocab[token]
             if len(postings_list) == 0 or postings_list[-2] != docid:
                 postings_list.append(docid)
@@ -46,34 +62,44 @@ with open(sys.argv[1], 'r') as file:
             else:
                 postings_list[-1] += 1
 
+            # Compute the document length
             document_length += 1
 
+# If we didn't index any documents then we're done.
 if docid == -1:
     sys.exit()
 
+# tell the user we've got to the end of parsing
 print(f"Indexed {docid + 1} documents. Serialising...")
 
+# Save the final document length
 length_vector.append(document_length)
 
+# store the primary keys
 with open("docids.bin", "w") as file:
     for doc in doc_ids:
         file.write(f"{doc}\n")
 
-with open("lengths.bin", "wb") as file:
-    length_vector.tofile(file)
-
 postings_fp = open("postings.bin", "wb")
 vocab_fp = open("vocab.bin", "wb")
 
+# serialise the in-memory index to disk
 for term, postings in vocab.items():
+    # write the postings list to one file
     where = postings_fp.tell()
     postings.tofile(postings_fp)
 
+    # write the vocabulary to a second file (one byte length, string, '\0', 4 byte where, 4 byte size)
     vocab_fp.write(struct.pack('B', len(term)))
     vocab_fp.write(term.encode())
-    vocab_fp.write(b'\0') # null termination
+    vocab_fp.write(b'\0') # string is null terminated
     vocab_fp.write(struct.pack('i', where))
-    vocab_fp.write(struct.pack('i', len(postings) * 4)) # no. bytes
+    vocab_fp.write(struct.pack('i', len(postings) * 4)) # no. of bytes
 
+# store the document lengths
+with open("lengths.bin", "wb") as file:
+    length_vector.tofile(file)
+
+# clean up
 postings_fp.close()
 vocab_fp.close()

--- a/JASSjr_index.py
+++ b/JASSjr_index.py
@@ -2,6 +2,7 @@
 
 from array import array
 from collections import defaultdict
+import re
 import struct
 import sys
 
@@ -15,28 +16,9 @@ doc_ids = []
 push_next = False
 vocab = defaultdict(lambda: array('i'))
 
-def lex(text):
-    current = 0
-    while True:
-        while current < len(text) and not text[current].isalnum() and text[current] != "<":
-            current += 1
-
-        start = current
-        if current < len(text) and text[current].isalnum():
-            while current < len(text) and text[current].isalnum() or text[current] == "-":
-                current += 1
-        elif current < len(text) and text[current] == "<":
-            current += 1
-            while current < len(text) and text[current-1] != ">":
-                current += 1
-        else:
-            break
-
-        yield text[start:current]
-
 with open(sys.argv[1], 'r') as file:
     for line in file:
-        for token in lex(line):
+        for token in re.findall("[a-zA-Z0-9][a-zA-Z0-9-]*|<[^>]*>", line):
             if token == "<DOC>":
                 if docid != -1:
                     length_vector.append(document_length)

--- a/JASSjr_index.py
+++ b/JASSjr_index.py
@@ -15,10 +15,11 @@ length_vector = array('i')
 doc_ids = []
 push_next = False
 vocab = defaultdict(lambda: array('i'))
+lexer = re.compile("[a-zA-Z0-9][a-zA-Z0-9-]*|<[^>]*>")
 
 with open(sys.argv[1], 'r') as file:
     for line in file:
-        for token in re.findall("[a-zA-Z0-9][a-zA-Z0-9-]*|<[^>]*>", line):
+        for token in lexer.findall(line):
             if token == "<DOC>":
                 if docid != -1:
                     length_vector.append(document_length)

--- a/JASSjr_search.py
+++ b/JASSjr_search.py
@@ -74,17 +74,17 @@ try:
                 for docid, freq in struct.iter_unpack('ii', contents_postings[offset:offset+size]):
                     # Process the postings list by simply adding the BM25 component for this document into the accumulators array
                     rsv = idf * ((freq * (k1 + 1)) / (freq + k1 * (1 - b + b * (doc_lengths[docid] / average_length))))
-                    current_rsv = accumulators[docid][1]
-                    accumulators[docid] = (docid, current_rsv + rsv)
+                    current_rsv = accumulators[docid][0]
+                    accumulators[docid] = (current_rsv + rsv, docid)
             except KeyError:
                 pass
 
-        # Sort the results list
-        accumulators.sort(key=lambda x: x[1], reverse=True)
+        # Sort the results list. Tie break on the document ID.
+        accumulators.sort(reverse=True)
 
         # Print the (at most) top 1000 documents in the results list in TREC eval format which is:
         # query-id Q0 document-id rank score run-name
-        for i, (docid, rsv) in enumerate(accumulators, start=1):
+        for i, (rsv, docid) in enumerate(accumulators, start=1):
             if rsv == 0 or i == 1001:
                 break
             print("{} Q0 {} {} {:.4f} JASSjr".format(query_id, doc_ids[docid][:-1], i, rsv))

--- a/JASSjr_search.py
+++ b/JASSjr_search.py
@@ -52,15 +52,18 @@ try:
             query_id = terms.popleft()
 
         for term in terms:
-            offset, size = vocab[term]
+            try:
+                offset, size = vocab[term]
 
-            postings_length = size / 8
-            idf = math.log(len(doc_lengths) / (postings_length))
+                postings_length = size / 8
+                idf = math.log(len(doc_lengths) / (postings_length))
 
-            for docid, freq in struct.iter_unpack('ii', contents_postings[offset:offset+size]):
-                rsv = idf * ((freq * (k1 + 1)) / (freq + k1 * (1 - b + b * (doc_lengths[docid] / average_length))))
-                current_rsv = accumulators[docid][1]
-                accumulators[docid] = (docid, current_rsv + rsv)
+                for docid, freq in struct.iter_unpack('ii', contents_postings[offset:offset+size]):
+                    rsv = idf * ((freq * (k1 + 1)) / (freq + k1 * (1 - b + b * (doc_lengths[docid] / average_length))))
+                    current_rsv = accumulators[docid][1]
+                    accumulators[docid] = (docid, current_rsv + rsv)
+            except KeyError:
+                pass
 
         accumulators.sort(key=lambda x: x[1], reverse=True)
 

--- a/JASSjr_search.py
+++ b/JASSjr_search.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+import struct
+
+def read_file(filename):
+    with open(filename, mode='rb') as file:
+            return file.read()
+
+def read_lines(filename):
+    with open(filename, mode='rb') as file:
+            return file.readlines()
+
+def decode_vocab(buffer):
+    offset = 0
+    while offset < len(buffer):
+        length, = struct.unpack_from('B', buffer, offset=offset)
+        offset += 1
+
+        word, = struct.unpack_from(f'{length}s', buffer, offset=offset)
+        offset += length + 1 # Null terminated
+
+        where, size = struct.unpack_from('ii', buffer, offset=offset)
+        offset += 8
+
+        yield word, where, size
+
+contents_vocab = read_file('vocab.bin')
+contents_lengths = read_file('lengths.bin')
+contents_postings = read_file('postings.bin')
+
+docids = read_lines('docids.bin')
+
+vocab = {}
+for word, offset, size in decode_vocab(contents_vocab):
+    vocab[word.decode()] = (offset, size)
+
+query = input('> ')
+
+offset, size = vocab[query]
+
+for pair in struct.iter_unpack('ii', contents_postings[offset:offset+size]):
+    print(docids[pair[0]], pair[1])


### PR DESCRIPTION
Adds a Python implementation of JASSjr to go alongside the Java and C++ versions

I have verified the output is the same through the following comparisons:
* docids.bin is the exact same
* lengths.bin is the exact same
* vocab.bin is the same size (it is stored in a different order)
* postings.bin is the same size (it is stored in a different order)
* print the tokens to compare the tokenizer is the exact same
* execute an example query and compare the output is the exact same

Here are some example timings for the three versions on my machine:
| | Time to index (s) | Time for one query (s) | Time for ten queries (s) |
| - | - | - | - |
| C++ | 20 | 0.45 | 0.60 |
| Java | 30 | 0.55 | 1.50 |
| Python | 115 | 1.40 | 2.25 |