### PR TITLE
JASSjr in JavaScript

### DIFF
--- a/JASSjr_index.js
+++ b/JASSjr_index.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+// JASSjr_index.js
+// Copyright (c) 2023 Vaughan Kitchen
+// Minimalistic BM25 search engine.
+
+var fs = require('fs');
+var os = require('os');
+var readline = require('readline');
+
+if (process.argv.length != 3) {
+	console.log('Usage: %s %s <infile.xml>', process.argv[0], process.argv[1]);
+	process.exit(1);
+}
+
+var vocab = {};
+var doc_ids = [];
+var length_vector = [];
+
+var docid = -1;
+var document_length = 0;
+var push_next = false;
+
+var rl = readline.createInterface({
+	input: fs.createReadStream(process.argv[2]),
+	crlfDelay: Infinity,
+});
+
+var token_count = 0;
+var line_count = 0;
+
+rl.on('line', function (line) {
+	for (var match of line.matchAll(/[a-zA-Z0-9][a-zA-Z0-9-]*|<[^>]*>/g)) {
+		var token = match[0];
+		if (token == '<DOC>') {
+			if (docid != -1)
+				length_vector.push(document_length);
+			docid++;
+			document_length = 0;
+			if (docid % 1000 == 0)
+				console.log('%d documents indexed', docid);
+		}
+		if (push_next) {
+			doc_ids.push(token);
+			push_next = false;
+		}
+		if (token == '<DOCNO>')
+			push_next = true;
+		if (token[0] == '<')
+			continue;
+
+		token = token.toLowerCase();
+
+		token = token.slice(0, 255);
+
+		if (!vocab.hasOwnProperty(token))
+			vocab[token] = [];
+
+		postings_list = vocab[token];
+		if (postings_list.length == 0 || postings_list[postings_list.length - 2] != docid) {
+			postings_list.push(docid);
+			postings_list.push(1);
+		} else {
+			postings_list[postings_list.length-1]++;
+		}
+
+		document_length += 1;
+	}
+});
+
+rl.on('close', function () {
+	if (docid == -1)
+		process.exit(0);
+
+	console.log('Indexed %d documents. Serialising...', docid + 1);
+
+	length_vector.push(document_length);
+
+	fs.writeFileSync('docids.bin', doc_ids.join(os.EOL) + '\n');
+
+	fs.writeFileSync('lengths.bin', Uint32Array.from(length_vector));
+
+	var postings_fd = fs.createWriteStream('postings.bin');
+	var vocab_fd = fs.createWriteStream('vocab.bin');
+
+	var buffer8 = Buffer.alloc(1);
+	var buffer32 = Buffer.alloc(4);
+
+	var where = 0;
+	for (var term in vocab) {
+		var postings = Uint32Array.from(vocab[term]);
+		postings_fd.write(Buffer.from(postings.buffer));
+
+		buffer8.writeUInt8(term.length);
+		vocab_fd.write(Buffer.from(buffer8));
+
+		vocab_fd.write(term);
+
+		buffer8.writeUInt8(0);
+		vocab_fd.write(Buffer.from(buffer8));
+
+		buffer32.writeUInt32LE(where);
+		vocab_fd.write(Buffer.from(buffer32));
+
+		buffer32.writeUInt32LE(postings.buffer.byteLength);
+		vocab_fd.write(Buffer.from(buffer32));
+
+		where += postings.buffer.byteLength;
+	}
+
+	postings_fd.end();
+	vocab_fd.end();
+});
+

--- a/JASSjr_index.js
+++ b/JASSjr_index.js
@@ -8,18 +8,19 @@ var fs = require('fs');
 var os = require('os');
 var readline = require('readline');
 
+// Make sure we have one paramter, the filename
 if (process.argv.length != 3) {
 	console.log('Usage: %s %s <infile.xml>', process.argv[0], process.argv[1]);
 	process.exit(1);
 }
 
-var vocab = {};
-var doc_ids = [];
-var length_vector = [];
+var vocab = {}; // the in-memory index
+var doc_ids = []; // the primary keys
+var length_vector = []; // hold the length of each document
 
 var docid = -1;
 var document_length = 0;
-var push_next = false;
+var push_next = false; // is the next token the primary key?
 
 var rl = readline.createInterface({
 	input: fs.createReadStream(process.argv[2]),
@@ -30,32 +31,42 @@ var token_count = 0;
 var line_count = 0;
 
 rl.on('line', function (line) {
+	// A token is either an XML tag '<'..'>' or a sequence of alpha-numerics.
+	// TREC <DOCNO> primary keys have a hyphen in them
 	for (var match of line.matchAll(/[a-zA-Z0-9][a-zA-Z0-9-]*|<[^>]*>/g)) {
 		var token = match[0];
+		// If we see a <DOC> tag then we're at the start of the next document
 		if (token == '<DOC>') {
+			// Save the previous document length
 			if (docid != -1)
 				length_vector.push(document_length);
+			// Move on to the next document
 			docid++;
 			document_length = 0;
 			if (docid % 1000 == 0)
 				console.log('%d documents indexed', docid);
 		}
+		// if the last token we saw was a <DOCNO> then the next token is the primary key
 		if (push_next) {
 			doc_ids.push(token);
 			push_next = false;
 		}
 		if (token == '<DOCNO>')
 			push_next = true;
+		// Don't index XML tags
 		if (token[0] == '<')
 			continue;
 
+		// lower case the string
 		token = token.toLowerCase();
 
+		// truncate any long tokens at 255 charactes (so that the length can be stored first and in a single byte)
 		token = token.slice(0, 255);
 
 		if (!vocab.hasOwnProperty(token))
 			vocab[token] = [];
 
+		// add the posting to the in-memory index
 		postings_list = vocab[token];
 		if (postings_list.length == 0 || postings_list[postings_list.length - 2] != docid) {
 			postings_list.push(docid);
@@ -64,20 +75,26 @@ rl.on('line', function (line) {
 			postings_list[postings_list.length-1]++;
 		}
 
+		// Compute the document length
 		document_length += 1;
 	}
 });
 
 rl.on('close', function () {
+	// If we didn't index any documents then we're done.
 	if (docid == -1)
 		process.exit(0);
 
+	// tell the user we've got to the end of parsing
 	console.log('Indexed %d documents. Serialising...', docid + 1);
 
+	// Save the final document length
 	length_vector.push(document_length);
 
+	// store the primary keys
 	fs.writeFileSync('docids.bin', doc_ids.join(os.EOL) + '\n');
 
+	// store the document lengths
 	fs.writeFileSync('lengths.bin', Uint32Array.from(length_vector));
 
 	var postings_fd = fs.createWriteStream('postings.bin');
@@ -86,11 +103,14 @@ rl.on('close', function () {
 	var buffer8 = Buffer.alloc(1);
 	var buffer32 = Buffer.alloc(4);
 
+	// serialise the in-memory index to disk
 	var where = 0;
 	for (var term in vocab) {
+		// write the postings list to one file
 		var postings = Uint32Array.from(vocab[term]);
 		postings_fd.write(Buffer.from(postings.buffer));
 
+		// write the vocabulary to a second file (one byte length, string, '\0', 4 byte where, 4 byte size)
 		buffer8.writeUInt8(term.length);
 		vocab_fd.write(Buffer.from(buffer8));
 
@@ -108,6 +128,7 @@ rl.on('close', function () {
 		where += postings.buffer.byteLength;
 	}
 
+	// clean up
 	postings_fd.end();
 	vocab_fd.end();
 });

--- a/JASSjr_search.js
+++ b/JASSjr_search.js
@@ -17,8 +17,7 @@ var b = 0.4; // BM25 b parameter
 var vocab_raw = fs.readFileSync('vocab.bin');
 var postings_raw = fs.readFileSync('postings.bin');
 var doc_lengths = fs.readFileSync('lengths.bin');
-// TODO benchmark vs latin1
-var ids = fs.readFileSync('docids.bin').toString().split(os.EOL);
+var ids = fs.readFileSync('docids.bin', 'utf8').split(os.EOL);
 
 var documents_in_collection = doc_lengths.length / 4;
 var average_document_length = 0;

--- a/JASSjr_search.js
+++ b/JASSjr_search.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+// JASSjr_search.js
+// Copyright (c) 2023 Vaughan Kitchen
+// Minimalistic BM25 search engine.
+
+var fs = require('fs');
+var os = require('os');
+var readline = require('readline').createInterface({
+	input: process.stdin,
+	output: process.stdout,
+});
+
+var k1 = 0.9; // BM25 k1 parameter
+var b = 0.4; // BM25 b parameter
+
+var vocab_raw = fs.readFileSync('vocab.bin');
+var postings_raw = fs.readFileSync('postings.bin');
+var doc_lengths = fs.readFileSync('lengths.bin');
+// TODO benchmark vs latin1
+var ids = fs.readFileSync('docids.bin').toString().split(os.EOL);
+
+var documents_in_collection = doc_lengths.length / 4;
+var average_document_length = 0;
+for (var i = 0; i < doc_lengths.length; i += 4)
+	average_document_length += doc_lengths.subarray(i, i+4).readUInt32LE();
+average_document_length /= documents_in_collection;
+
+var vocab = {};
+
+// decode the vocabulary (one byte length, string, '\0', 4 byte where, 4 byte size)
+for (var offset = 0; offset < vocab_raw.length;) {
+	var length = vocab_raw[offset];
+	offset++;
+
+	var word = vocab_raw.subarray(offset, offset+length).toString();
+	offset += length+1; // null terminated
+
+	vocab[word] = offset;
+	offset += 8;
+}
+
+readline.question('', search);
+
+function search(query) {
+	var query_id = 0;
+	var accumulators = new Array(documents_in_collection);
+
+	var terms = query.split(' ');
+	if (!isNaN(terms[0]))
+		query_id = terms.shift();
+
+	terms.forEach(function (term) {
+		var offset = vocab[term];
+		if (offset === undefined)
+			return;
+
+		var where = vocab_raw.subarray(offset, offset+4).readUInt32LE();
+		var size = vocab_raw.subarray(offset+4, offset+8).readUInt32LE();
+
+		var documents_in_postings = size / 8;
+		var idf = Math.log(documents_in_collection / documents_in_postings)
+
+		for (var i = where; i < where+size; i += 8) {
+			var docid = postings_raw.subarray(i, i+4).readUInt32LE();
+			var freq = postings_raw.subarray(i+4, i+8).readUInt32LE();
+
+			var doc_length = doc_lengths.subarray(docid*4, docid*4+4).readUInt32LE();
+
+			var rsv = idf * ((freq * (k1 + 1)) / (freq + k1 * (1 - b + b * (doc_length / average_document_length))))
+			var current = accumulators[docid] || [0, 0]
+			accumulators[docid] = [docid, current[1] + rsv];
+		}
+	});
+
+	accumulators.sort(function (a, b) { return b[1] - a[1] || b[0] - a[0] });
+
+	for (var i = 0; i < accumulators.length; i++) {
+		var pair = accumulators[i];
+		if (!pair || i == 1000)
+			break;
+		var docid = pair[0];
+		var rsv = pair[1];
+		console.log('%d Q0 %s %d %s JASSjr', query_id, ids[docid], i+1, rsv.toLocaleString('en-US', { minimumFractionDigits: 4, maximumFractionDigits: 4 }));
+	}
+
+	readline.question('', search);
+}


### PR DESCRIPTION
Adds a JavaScript implementation of JASSjr to go alongside the Java, C++, and Python versions

I have verified the output is the same through the following comparisons:
* docids.bin is the exact same
* lengths.bin is the exact same
* vocab.bin is the same size (it is stored in a different order)
* postings.bin is the same size (it is stored in a different order)
* uses the same tokenizer as the Python version
* execute an example query and compare the output is the exact same

Here are some example timings for the four versions on my machine:
| | Time to index (s) | Time for one query (s) | Time for ten queries (s) |
| - | - | - | - |
| C++ | 20 | 0.45 | 0.60 |
| Java | 30 | 0.55 | 1.50 |
| Python | 115 | 1.40 | 2.25 |
| JavaScript | 65 |  1.00 | 2.10 |