### PR TITLE
JASSjr in Elixir

### DIFF
--- a/JASSjr_index.exs
+++ b/JASSjr_index.exs
@@ -1,4 +1,6 @@
-#!/usr/bin/env -S ERL_FLAGS="+B +hms 1000000" elixir
+#!/usr/bin/env -S ERL_FLAGS="+B +hms 1073741824" elixir
+# +B disables interrupt handler
+# +hms sets default heap size (8gb)
 
 defmodule Postings do
   defstruct length: 0, docno: 0, lengths: [], docnos: [], terms: %{}

--- a/JASSjr_index.exs
+++ b/JASSjr_index.exs
@@ -84,9 +84,10 @@ defmodule Indexer do
 
   def serialise(result) do
     result = %Postings{result | lengths: [ result.length | result.lengths]}
+    docnos = Enum.reverse(result.docnos)
 
     File.open!("docids.bin", [:write], fn file ->
-      Enum.each(result.docnos, fn docno ->
+      Enum.each(docnos, fn docno ->
         IO.write(file, "#{docno}\n")
       end)
     end)
@@ -102,7 +103,8 @@ defmodule Indexer do
     :ok = File.close(postings)
     :ok = File.close(vocab)
 
-    lengths = for x <- result.lengths, do: <<x::native-32>>, into: <<>>
+    lengths = Enum.reverse(result.lengths)
+    lengths = for x <- lengths, do: <<x::native-32>>, into: <<>>
     File.open!("lengths.bin", [:write], fn file ->
       IO.binwrite(file, lengths)
     end)

--- a/JASSjr_index.exs
+++ b/JASSjr_index.exs
@@ -21,6 +21,10 @@ defmodule Indexer do
 
   def parse_tag(file, result) do
     if String.starts_with?(file, "<DOCNO>") do
+      if length(result.docnos) |> rem(1000) == 0 do
+        IO.puts("#{length(result.docnos)} documents indexed")
+      end
+
       {_, file} = String.split_at(file, 7)
       [docno, file] = String.split(file, "</DOCNO>", parts: 2)
       docno = String.trim(docno)
@@ -32,10 +36,6 @@ defmodule Indexer do
       end
 
       result = Postings.append(result, docno)
-
-      if length(result.docnos) |> rem(1000) == 0 do
-        IO.puts("#{length(result.docnos)} documents indexed")
-      end
 
       parse(file, result)
     else
@@ -120,6 +120,6 @@ end
 
 file = File.read!(filename)
 
-result = Indexer.parse(file)
-Indexer.serialise(result)
-# IO.inspect(result)
+index = Indexer.parse(file)
+IO.puts("Indexed #{index.docno} documents. Serialising...")
+Indexer.serialise(index)

--- a/JASSjr_index.exs
+++ b/JASSjr_index.exs
@@ -1,10 +1,10 @@
 #!/usr/bin/env -S ERL_FLAGS="+B +hms 1000000" elixir
 
 defmodule Postings do
-  defstruct length: 0, lengths: [], docnos: [], terms: %{}
+  defstruct length: 0, docno: 0, lengths: [], docnos: [], terms: %{}
 
   def append(postings, term) do
-      docid = length(postings.docnos) - 1
+      docid = postings.docno - 1
       %Postings{postings | length: postings.length + 1, terms: Map.update(postings.terms, term, %{ docid => 1 },
         fn docnos -> Map.update(docnos, docid, 1, fn tf -> tf + 1 end) end) }
   end
@@ -26,9 +26,9 @@ defmodule Indexer do
       docno = String.trim(docno)
 
       result = if length(result.docnos) > 0 do
-        %Postings{result | length: 0, lengths: [ result.length | result.lengths], docnos: [ docno | result.docnos]}
+        %Postings{result | length: 0, lengths: [ result.length | result.lengths], docno: result.docno + 1, docnos: [ docno | result.docnos]}
       else
-        %Postings{result | docnos: [ docno | result.docnos]}
+        %Postings{result | docno: result.docno + 1, docnos: [ docno | result.docnos]}
       end
 
       result = Postings.append(result, docno)

--- a/JASSjr_index.exs
+++ b/JASSjr_index.exs
@@ -16,8 +16,8 @@ defmodule Indexer do
   def parse_tag(file, result) do
     if String.starts_with?(file, "<DOCNO>") do
       {_, file} = String.split_at(file, 7)
-      file = String.trim_leading(file)
-      {docno, file} = String.split_at(file, 14)
+      [docno, file] = String.split(file, "</DOCNO>", parts: 2)
+      docno = String.trim(docno)
 
       result = %{result | docnos: [ docno | result.docnos]}
 

--- a/JASSjr_index.exs
+++ b/JASSjr_index.exs
@@ -31,6 +31,8 @@ defmodule Indexer do
         %Postings{result | docnos: [ docno | result.docnos]}
       end
 
+      result = Postings.append(result, docno)
+
       if length(result.docnos) |> rem(1000) == 0 do
         IO.puts("#{length(result.docnos)} documents indexed")
       end

--- a/JASSjr_index.exs
+++ b/JASSjr_index.exs
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S ERL_FLAGS="+hms 1000000" elixir
+#!/usr/bin/env -S ERL_FLAGS="+B +hms 1000000" elixir
 
 defmodule Postings do
   defstruct docnos: [], terms: %{}

--- a/JASSjr_index.exs
+++ b/JASSjr_index.exs
@@ -1,0 +1,94 @@
+#!/usr/bin/env -S ERL_FLAGS="+hms 1000000" elixir
+
+defmodule Postings do
+  defstruct docnos: [], terms: %{}
+end
+
+defmodule Indexer do
+  def consume_tag(<<head, tail::binary>>, result) do
+    case head do
+      # '>'
+      62 -> parse(tail, result)
+      _ -> consume_tag(tail, result)
+    end
+  end
+
+  def parse_tag(file, result) do
+    if String.starts_with?(file, "<DOCNO>") do
+      {_, file} = String.split_at(file, 7)
+      file = String.trim_leading(file)
+      {docno, file} = String.split_at(file, 14)
+
+      result = %{result | docnos: [ docno | result.docnos]}
+
+      if length(result.docnos) |> rem(1000) == 0 do
+        IO.puts("#{length(result.docnos)} documents indexed")
+      end
+
+      parse(file, result)
+    else
+      consume_tag(file, result)
+    end
+  end
+
+  def parse_number(file, result, val \\ <<>>)
+  # TODO push final
+  def parse_number(<<>>, result, _val), do: result
+  def parse_number(<<head, tail::binary>> = file, result, val) do
+    case head do
+      # Numeric
+      x when x in 48..57 -> parse_number(tail, result, val <> <<x>>)
+      _ ->
+        [ docno | _ ] = result.docnos
+        result = %{result | terms: Map.update(result.terms, val, %{ docno => 1 },
+          fn docnos -> Map.update(docnos, docno, 1, fn tf -> tf + 1 end) end) }
+        parse(file, result)
+    end
+  end
+
+  def parse_string(file, result, val \\ <<>>)
+  # TODO push final
+  def parse_string(<<>>, result, _val), do: result
+  def parse_string(<<head, tail::binary>> = file, result, val) do
+    case head do
+      # Uppercase
+      x when x in 65..90 -> parse_string(tail, result, val <> <<x+32>>)
+      # Lowercase
+      x when x in 97..122 -> parse_string(tail, result, val <> <<x>>)
+      _ ->
+        [ docno | _ ] = result.docnos
+        result = %{result | terms: Map.update(result.terms, val, %{ docno => 1 },
+          fn docnos -> Map.update(docnos, docno, 1, fn tf -> tf + 1 end) end) }
+        parse(file, result)
+    end
+  end
+
+  def parse(file, result \\ %Postings{})
+  def parse(<<>>, result), do: result
+  def parse(<<head, tail::binary>> = file, result) do
+    case head do
+      # Tag '<'
+      60 -> parse_tag(file, result)
+      # Numeric
+      x when x in 48..57 -> parse_number(file, result)
+      # Uppercase
+      x when x in 65..90 -> parse_string(file, result)
+      # Lowercase
+      x when x in 97..122 -> parse_string(file, result)
+      # Other
+      _ -> parse(tail, result)
+    end
+  end
+end
+
+if length(System.argv()) != 1 do
+  IO.puts("Usage: ./JASSjr_index.exs <infile.xml>")
+  System.halt()
+end
+
+[ filename | _ ] = System.argv()
+
+file = File.read!(filename)
+
+result = Indexer.parse(file)
+IO.inspect(result)

--- a/JASSjr_index.exs
+++ b/JASSjr_index.exs
@@ -2,6 +2,9 @@
 # +B disables interrupt handler
 # +hms sets default heap size (8gb)
 
+# Copyright (c) 2024 Vaughan Kitchen
+# Minimalistic BM25 search engine.
+
 defmodule Index do
   defstruct length: 0, # length of currently indexing document
   docno: 0, # cache last index into primary keys

--- a/JASSjr_search.exs
+++ b/JASSjr_search.exs
@@ -1,7 +1,9 @@
 #!/usr/bin/env -S ERL_FLAGS="+B +hms 1000000" elixir
+# +B disables interrupt handler
+# +hms sets default heap size (8mb)
 
 defmodule Index do
-  defstruct average_length: 0, docnos: [], lengths: [], vocab: %{}, postings: nil
+  defstruct average_length: 0, docnos: [], lengths: [], vocab: %{}, postings_fh: nil
 end
 
 defmodule SearchEngine do
@@ -9,17 +11,20 @@ defmodule SearchEngine do
     k1 = 0.9 # BM25 k1 parameter
     b = 0.4 # BM25 b parameter
 
+    # Compute the IDF component of BM25 as log(N/n)
     idf = :math.log(:array.size(index.lengths) / num_results)
     idf * ((freq * (k1 + 1)) / (freq + k1 * (1 - b + b * (:array.get(docno, index.lengths) / index.average_length))))
   end
 
+  # Seek and read the postings list
   def read_postings(index, { where, count}) do
-    {:ok, data} = :file.pread(index.postings, where, count)
+    {:ok, data} = :file.pread(index.postings_fh, where, count)
     for <<docno::native-32, freq::native-32 <- data>>, into: %{}, do: {docno, rsv(index, count / 8, docno, freq)}
   end
 
   def search(index, query) do
     Enum.map(query, fn term ->
+      # Does the term exist in the collection?
       case Map.fetch(index.vocab, term) do
         {:ok, loc} -> read_postings(index, loc)
         :error -> %{}
@@ -30,6 +35,8 @@ defmodule SearchEngine do
     end)
   end
 
+  # Print the (at most) top 1000 documents in the results list in TREC eval format which is:
+  # query-id Q0 document-id rank score run-name
   def print(results, index, query_id) do
     results
     |> Map.to_list
@@ -45,6 +52,7 @@ defmodule SearchEngine do
   def accept_input(index) do
     query = IO.gets("")
     if query != :eof do
+      # If the first token is a number then assume a TREC query number, and skip it
       query = String.split(query)
       [ head | tail ] = query
       { query_id, query } = case Integer.parse(head) do
@@ -63,8 +71,8 @@ defmodule SearchEngine do
     average_length = :array.foldl(fn _, val, acc -> acc + val end, 0, lengths) / :array.size(lengths)
     vocab = for <<len::8, term::binary-size(len), 0::8, post_where::native-32, post_len::native-32 <- File.read!("vocab.bin")>>, into: %{}, do: {term, {post_where, post_len}}
 
-    File.open!("postings.bin", fn postings ->
-      accept_input(%Index{average_length: average_length, docnos: docnos, lengths: lengths, vocab: vocab, postings: postings})
+    File.open!("postings.bin", fn postings_fh ->
+      accept_input(%Index{average_length: average_length, docnos: docnos, lengths: lengths, vocab: vocab, postings_fh: postings_fh})
     end)
   end
 end

--- a/JASSjr_search.exs
+++ b/JASSjr_search.exs
@@ -39,7 +39,7 @@ defmodule SearchEngine do
   def print(index, results) do
     results
     |> Map.to_list
-    |> Enum.sort(fn {_, tf1}, {_, tf2} -> tf1 >= tf2 end)
+    |> Enum.sort_by(fn {docid, tf} -> {tf, docid} end, :desc)
     |> Enum.take(1000)
     |> Enum.with_index
     |> Enum.each(fn {{res, tf}, i} ->

--- a/JASSjr_search.exs
+++ b/JASSjr_search.exs
@@ -2,6 +2,9 @@
 # +B disables interrupt handler
 # +hms sets default heap size (8mb)
 
+# Copyright (c) 2024 Vaughan Kitchen
+# Minimalistic BM25 search engine.
+
 defmodule Index do
   defstruct average_length: 0, docnos: [], lengths: [], vocab: %{}, postings_fh: nil
 end

--- a/JASSjr_search.exs
+++ b/JASSjr_search.exs
@@ -59,9 +59,8 @@ defmodule SearchEngine do
 
   def start() do
     docnos = File.read!("docids.bin") |> String.split
-    lengths = for <<x::native-32 <- File.read!("lengths.bin")>>, do: x
-    average_length = Enum.sum(lengths) / length(lengths)
-    lengths = :array.from_list(lengths)
+    lengths = :array.from_list(for <<x::native-32 <- File.read!("lengths.bin")>>, do: x)
+    average_length = :array.foldl(fn _, val, acc -> acc + val end, 0, lengths) / :array.size(lengths)
     vocab = for <<len::8, term::binary-size(len), 0::8, post_where::native-32, post_len::native-32 <- File.read!("vocab.bin")>>, into: %{}, do: {term, {post_where, post_len}}
 
     File.open!("postings.bin", fn postings ->

--- a/JASSjr_search.exs
+++ b/JASSjr_search.exs
@@ -1,0 +1,66 @@
+#!/usr/bin/env -S ERL_FLAGS="+B +hms 1000000" elixir
+
+# k1 = 0.9 # BM25 k1 parameter
+# b = 0.4 # BM25 b parameter
+
+defmodule Index do
+  defstruct docnos: [], lengths: [], vocab: %{}
+end
+
+defmodule SearchEngine do
+  def read_postings({ where, count}) do
+    file = File.open!("postings.bin")
+    {:ok, data} = :file.pread(file, where, count)
+    File.close(file)
+    for <<docno::native-32, count::native-32 <- data>>, into: %{}, do: {docno, count}
+  end
+
+  def search(index, query) do
+    query = String.split(query)
+    [ head | tail ] = query
+    query = case Integer.parse(head) do
+      :error -> query
+      _ -> tail
+    end
+    results = Enum.map(query, fn term ->
+      case Map.fetch(index.vocab, term) do
+        {:ok, loc} -> read_postings(loc)
+        :error -> %{}
+      end
+    end)
+    Enum.reduce(results, fn x, acc ->
+      Map.merge(acc, x, fn _k, v1, v2 -> v1 + v2 end)
+    end)
+  end
+
+  def print(index, results) do
+    results
+    |> Map.to_list
+    |> Enum.sort(fn {_, tf1}, {_, tf2} -> tf1 >= tf2 end)
+    |> Enum.take(1000)
+    |> Enum.with_index
+    |> Enum.each(fn {{res, tf}, i} ->
+      docno = Enum.at(index.docnos, res)
+      IO.puts("0 Q0 #{docno} #{i+1} #{tf} JASSjr")
+    end)
+  end
+
+  def accept_input(index) do
+    query = IO.gets("")
+    if query != :eof do
+      results = search(index, query)
+      print(index, results)
+      accept_input(index)
+    end
+  end
+
+  def start() do
+    docnos = File.read!("docids.bin") |> String.split
+    lengths = for <<x::native-32 <- File.read!("lengths.bin")>>, do: x
+    vocab = for <<len::8, term::binary-size(len), 0::8, post_where::native-32, post_len::native-32 <- File.read!("vocab.bin")>>, into: %{}, do: {term, {post_where, post_len}}
+
+    accept_input(%Index{docnos: docnos, lengths: lengths, vocab: vocab})
+  end
+end
+
+SearchEngine.start()

--- a/JASSjr_search.exs
+++ b/JASSjr_search.exs
@@ -43,7 +43,7 @@ defmodule SearchEngine do
     |> Enum.take(1000)
     |> Enum.with_index
     |> Enum.each(fn {{res, tf}, i} ->
-      docno = Enum.at(index.docnos, res)
+      docno = :array.get(res, index.docnos)
       IO.puts("0 Q0 #{docno} #{i+1} #{:io_lib.format("~.4f", [tf])} JASSjr")
     end)
   end
@@ -58,7 +58,7 @@ defmodule SearchEngine do
   end
 
   def start() do
-    docnos = File.read!("docids.bin") |> String.split
+    docnos = :array.from_list(File.read!("docids.bin") |> String.split)
     lengths = :array.from_list(for <<x::native-32 <- File.read!("lengths.bin")>>, do: x)
     average_length = :array.foldl(fn _, val, acc -> acc + val end, 0, lengths) / :array.size(lengths)
     vocab = for <<len::8, term::binary-size(len), 0::8, post_where::native-32, post_len::native-32 <- File.read!("vocab.bin")>>, into: %{}, do: {term, {post_where, post_len}}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 JASSjr, the minimalistic BM25 search engine for indexing and searching the TREC WSJ collection.
 
 Copyright (c) 2019 Andrew Trotman and Kat Lilly
+Copyright (c) 2023, 2024 Vaughan Kitchen
 Released under the 2-clause BSD licence.
 
 Please fork our repo.  Please report any bugs.
@@ -48,6 +49,24 @@ The Java version is build in the same way, but run with
 and
 
 	java JASSjr_search
+
+## Elixir ##
+The Elixir version can also be built manually to reduce startup times when searching
+
+	echo 'null' | elixirc JASSjr_search.exs > /dev/null
+
+and then run with
+
+	elixir -e 'SearchEngine.start'
+
+## Other ##
+The interpreted languages include a shebang and can be executed directly e.g.
+
+    ./JASSjr_index.py <filename>
+
+and
+
+    ./JASSjr_search.py
 
 # Evaluation #
 * Indexing the TREC WSJ collection of 173,252 documents takes less than 20 seconds on my Mac (3.2 GHz Intel Core i5).
@@ -101,6 +120,12 @@ So JASSjr is not as fast as JASSv2, and not quite as good at ranking as JASSv2, 
 | JASSjr_search.cpp | C/C++ source code to search engine |
 | JASSjr_index.java | Java source code to indexer |
 | JASSjr_search.java | Java source code to search engine |
+| JASSjr_index.py | Python source code to indexer |
+| JASSjr_search.py | Python source code to search engine |
+| JASSjr_index.js | JavaScript source code to indexer |
+| JASSjr_search.js | JavaScript source code to search engine |
+| JASSjr_index.exs | Elixir source code to indexer |
+| JASSjr_search.exs | Elixir source code to search engine |
 | GNUmakefile | GNU make makefile for macOS / Linux |
 | makefile | NMAKE makefile for Windows |
 | test_documents.xml | Example of how documents should be layed out for indexing | 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # JASSjr #
 JASSjr, the minimalistic BM25 search engine for indexing and searching the TREC WSJ collection.
 
-Copyright (c) 2019 Andrew Trotman and Kat Lilly
-Copyright (c) 2023, 2024 Vaughan Kitchen
+Copyright (c) 2019 Andrew Trotman and Kat Lilly \
+Copyright (c) 2023, 2024 Vaughan Kitchen \
 Released under the 2-clause BSD licence.
 
 Please fork our repo.  Please report any bugs.


### PR DESCRIPTION
Adds an Elixir implementation of JASSjr to go alongside the others

I have verified the output is the same through the following comparisons:
* docids.bin is the exact same
* lengths.bin is the exact same
* vocab.bin is the same size (it is stored in a different order)
* postings.bin is the same size (it is stored in a different order)
* execute an example query and compare the output is the exact same

Uses a single character look ahead tokenizer. However this resulted in
joining lots of small strings so the garbage collector default heap size
was increased to improve performance and can now use 12gb RAM

Here are some example timings for the various versions on my machine:
| | Time to index (s) | Time for one query (s) | Time for 50 queries (s) |
| - | - | - | - |
| C++ | 15 | 0.35 | 3.90 |
| Java | 18 | 0.33 | 1.10 |
| Python | 74 | 0.85 | 2.80 |
| JavaScript | 35 |  0.75 | 3.80 |
| Elixir | 125 | 0.85 | 2.20 |