### PR TITLE
JASSjr in Ruby

### DIFF
--- a/JASSjr_index.rb
+++ b/JASSjr_index.rb
@@ -1,0 +1,91 @@
+#!/usr/bin/env ruby
+
+# Copyright (c) 2024 Vaughan Kitchen
+# Minimalistic BM25 search engine.
+
+# Make sure we have one parameter, the filename
+abort("Usage: #{$0} <infile.xml>") if ARGV.length != 1
+
+vocab = {} # the in-memory index
+doc_ids = [] # the primary keys
+length_vector = [] # hold the length of each document
+
+docid = -1
+document_length = 0
+push_next = false # is the next token the primary key?
+
+File.foreach(ARGV[0]) do |line|
+  # A token is either an XML tag '<'..'>' or a sequence of alpha-numerics.
+  # TREC <DOCNO> primary keys have a hyphen in them
+  line.scan(/[a-zA-Z0-9][a-zA-Z0-9-]*|<[^>]*>/).each do |token|
+    # If we see a <DOC> tag then we're at the start of the next document
+    if token == "<DOC>"
+      # Save the previous document length
+      length_vector << document_length if docid != -1
+      # Move on to the next document
+      docid += 1
+      document_length = 0
+      puts("#{docid} documents indexed") if docid % 1000 == 0
+    end
+    # if the last token we saw was a <DOCNO> then the next token is the primary key
+    if push_next
+      doc_ids << token.dup # Duplicate so that the primary key doesn't get downcased
+      push_next = false
+    end
+    push_next = true if token == "<DOCNO>"
+    # Don't index XML tags
+    next if token[0] == "<"
+
+    # lower case the string
+    token.downcase!
+
+    # truncate any long tokens at 255 charactes (so that the length can be stored first and in a single byte)
+    token = token.slice(0, 255)
+
+    # add the posting to the in-memory index
+    vocab[token] = [] if !vocab.key?(token)
+    postings_list = vocab[token]
+    if postings_list.length == 0 || postings_list[-2] != docid
+      postings_list << docid << 1
+    else
+      postings_list[-1] += 1
+    end
+
+    # Compute the document length
+    document_length += 1
+  end
+end
+
+# If we didn't index any documents then we're done.
+exit if docid == -1
+
+# tell the user we've got to the end of parsing
+puts("Indexed #{docid + 1} documents. Serialising...")
+
+# Save the final document length
+length_vector << document_length
+
+# store the primary keys
+File.open("docids.bin", "w") { |file| file.puts(doc_ids) }
+
+postings_fp = File.open("postings.bin", "wb")
+vocab_fp = File.open("vocab.bin", "wb")
+
+vocab.each do |term, postings|
+  # write the postings list to one file
+  where = postings_fp.pos
+  postings_fp.write(postings.pack("l*"))
+
+  # write the vocabulary to a second file (one byte length, string, '\0', 4 byte where, 4 byte size)
+  vocab_fp.write([term.length].pack("C"))
+  vocab_fp.write(term)
+  vocab_fp.write("\0")
+  vocab_fp.write([where, postings.length * 4].pack("ll"))
+end
+
+# store the document lengths
+File.open("lengths.bin", "w") { |file| file.write(length_vector.pack("l*")) }
+
+# clean up
+postings_fp.close
+vocab_fp.close

--- a/JASSjr_search.rb
+++ b/JASSjr_search.rb
@@ -1,0 +1,71 @@
+#!/usr/bin/env ruby
+
+# Copyright (c) 2024 Vaughan Kitchen
+# Minimalistic BM25 search engine.
+
+k1 = 0.9 # BM25 k1 parameter
+b = 0.4 # BM25 b parameter
+
+doc_ids = File.readlines("docids.bin", chomp: true) # Read the primary_keys
+doc_lengths = File.binread("lengths.bin").unpack("l*") # Read the document lengths
+average_length = doc_lengths.sum.to_f / doc_lengths.length
+vocab = {}
+
+vocab_raw = File.binread("vocab.bin")
+offset = 0
+
+# decode the vocabulary (unsigned byte length, string, '\0', 4 byte signed where, 4 signed byte size)
+while offset < vocab_raw.length do
+  length = vocab_raw.unpack("C", offset: offset)[0]
+  offset += 1
+
+  term = vocab_raw[offset...offset+length]
+  offset += length + 1 # Null terminated
+
+  postings_pair = vocab_raw.unpack("ll", offset: offset)
+  offset += 8
+
+  vocab[term] = postings_pair
+end
+
+# Search (one query per line)
+loop do
+  query = gets&.split
+  break if query.nil?
+
+  query_id = 0
+  accumulators = Array.new(doc_ids.length) { |i| [0, i] }
+
+  # If the first token is a number then assume a TREC query number, and skip it
+  begin
+    query_id = Integer(query[0])
+    query.shift
+  rescue ArgumentError
+  end
+
+  query.each do |term|
+    offset, size = vocab[term]
+    next if offset.nil? # Does the term exist in the collection?
+
+    # Seek and read the postings list
+    postings = File.binread("postings.bin", size, offset).unpack("l*")
+
+    # Compute the IDF component of BM25 as log(N/n).
+    idf = Math.log(doc_ids.length.to_f / (postings.length / 2))
+
+    # Process the postings list by simply adding the BM25 component for this document into the accumulators array
+    postings.each_slice(2) do |docid, tf|
+      rsv = idf * ((tf * (k1 + 1)) / (tf + k1 * (1 - b + b * (doc_lengths[docid] / average_length))))
+      accumulators[docid][0] += rsv
+    end
+  end
+
+  # Sort the results list. Tie break on the document ID.
+  accumulators.sort!.reverse!
+
+  # Print the (at most) top 1000 documents in the results list in TREC eval format which is:
+  # query-id Q0 document-id rank score run-name
+  accumulators.take_while { |rsv, | rsv > 0 }.take(1000).each_with_index do |(rsv, docid), i|
+    puts("#{query_id} Q0 #{doc_ids[docid]} #{i+1} #{'%.4f' % rsv} JASSjr")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ and then run with
 
 	elixir -e 'SearchEngine.start'
 
+## Ruby ##
+It is recommended to run the Ruby implementation with yjit where available. As this is not currently the default run with
+
+	ruby --yjit JASSjr_index.rb <filename>
+
+and then run with
+
+	ruby --yjit JASSjr_search.rb
+
 ## Other ##
 The interpreted languages include a shebang and can be executed directly e.g.
 
@@ -126,6 +135,8 @@ So JASSjr is not as fast as JASSv2, and not quite as good at ranking as JASSv2, 
 | JASSjr_search.js | JavaScript source code to search engine |
 | JASSjr_index.exs | Elixir source code to indexer |
 | JASSjr_search.exs | Elixir source code to search engine |
+| JASSjr_index.rb | Ruby source code to indexer |
+| JASSjr_search.rb | Ruby source code to search engine |
 | GNUmakefile | GNU make makefile for macOS / Linux |
 | makefile | NMAKE makefile for Windows |
 | test_documents.xml | Example of how documents should be layed out for indexing | 


### PR DESCRIPTION
Adds a Ruby implementation of JASSjr to go alongside the others.

This is a direct copy of the Python version with minor changes due to language differences

I have verified the output is the same through the following comparisons:
* docids.bin is the exact same
* lengths.bin is the exact same
* vocab.bin is the same size (it is stored in a different order)
* postings.bin is the same size (it is stored in a different order)
* execute an example query and compare the output is the exact same

Here are some example timings for the various versions on my machine:
| | Time to index (s) | Time for one query (s) | Time for 50 queries (s) |
| - | - | - | - |
| C++ | 15 | 0.35 | 3.90 |
| Java | 18 | 0.33 | 1.10 |
| Python | 74 | 0.85 | 2.80 |
| JavaScript | 35 |  0.75 | 3.80 |
| Elixir | 125 | 0.85 | 2.20 |
| Ruby 3.2.3 | 160 | 2.30 | 62.5 |
| Ruby 3.3.0 | 285 | 2.30 | 65.50 |
| Ruby 3.3.0 --yjit | 269 | 2.30 | 64.50 |

Ruby 3.2.3 was installed from void packages. Ruby 3.3.0 was installed using mise