### PR TITLE
JASSjr in Perl

### DIFF
--- a/JASSjr_index.pl
+++ b/JASSjr_index.pl
@@ -1,0 +1,101 @@
+#!/usr/bin/env perl
+
+# Copyright (c) 2024 Vaughan Kitchen
+# Minimalistic BM25 search engine.
+
+use v5.38;
+use strict;
+use warnings;
+use builtin qw(true false);
+no warnings 'experimental';
+
+# Make sure we have one parameter, the filename
+die "Usage: $0 <infile.xml>" if scalar @ARGV != 1;
+
+my %vocab; # the in-memory index
+my @doc_ids; # the primary keys
+my @length_vector; # hold the length of each document
+
+my $docid = -1;
+my $document_length = 0;
+my $push_next = false; # is the next token the primary key?
+
+while (<>) {
+	# A token is either an XML tag '<'..'>' or a sequence of alpha-numerics.
+	# TREC <DOCNO> primary keys have a hyphen in them
+	foreach (m/[a-zA-Z0-9][a-zA-Z0-9-]*|<[^>]*>/g) {
+		# If we see a <DOC> tag then we're at the start of the next document
+		if ($_ eq '<DOC>') {
+			# Save the previous document length
+			push @length_vector, $document_length if $docid != -1;
+			# Move on to the next document
+			$docid += 1;
+			$document_length = 0;
+			say "$docid documents indexed" if $docid % 1000 == 0;
+		}
+		# if the last token we saw was a <DOCNO> then the next token is the primary key
+		if ($push_next) {
+			push @doc_ids, $_;
+			$push_next = false;
+		}
+		$push_next = true if $_ eq '<DOCNO>';
+		# Don't index XML tags
+		next if substr($_, 0, 1) eq '<';
+
+		# lower case the string
+		my $token = lc $_;
+		# truncate any long tokens at 255 charactes (so that the length can be stored first and in a single byte)
+		$token = substr $token, 0, 255;
+
+		# add the posting to the in-memory index
+		$vocab{$token} = [] if not exists $vocab{$token};
+		my $postings_list = $vocab{$token};
+		if (scalar @{$postings_list} == 0 || @{$postings_list}[-2] ne $docid) {
+			push @{$postings_list}, $docid, 1;
+		} else {
+			@{$postings_list}[-1] += 1;
+		}
+
+		# Compute the document length
+		$document_length += 1;
+	}
+}
+
+# If we didn't index any documents then we're done.
+exit if $docid == -1;
+
+# Save the final document length
+push @length_vector, $document_length;
+
+# tell the user we've got to the end of parsing
+say "Indexed @{[$docid + 1]} documents. Serialising...";
+
+# Save the final document length
+open my $docids_fh, '>', 'docids.bin' or die;
+foreach (@doc_ids) {
+	print $docids_fh "$_\n";
+}
+
+open my $postings_fh, '>:raw', 'postings.bin' or die;
+open my $vocab_fh, '>:raw', 'vocab.bin' or die;
+
+while (my ($term, $postings) = each %vocab) {
+	my @postings = @{$postings};
+
+	# write the postings list to one file
+	my $where = tell $postings_fh;
+	print $postings_fh pack 'l*', @postings;
+
+	# write the vocabulary to a second file (one byte length, string, '\0', 4 byte where, 4 byte size)
+	print $vocab_fh pack 'Ca*xll', length($term), $term, $where, scalar @postings * 4;
+}
+
+# store the document lengths
+open my $lengths_fh, '>:raw', 'lengths.bin' or die;
+print $lengths_fh pack 'l*', @length_vector;
+
+# clean up
+close $docids_fh;
+close $postings_fh;
+close $vocab_fh;
+close $lengths_fh;

--- a/JASSjr_search.pl
+++ b/JASSjr_search.pl
@@ -1,0 +1,92 @@
+#!/usr/bin/env perl
+
+# Copyright (c) 2024 Vaughan Kitchen
+# Minimalistic BM25 search engine.
+
+use v5.38;
+use strict;
+use warnings;
+
+my $K1 = 0.9; # BM25 k1 parameter
+my $B = 0.4; # BM25 b parameter
+
+sub slurp($filename) {
+	open my $fh, '<:raw', $filename or die;
+	die $! if not defined read $fh, my $content, -s $fh;
+	close $fh;
+	return $content;
+}
+
+# Read the primary_keys
+open my $fh, '<', 'docids.bin' or die;
+chomp(my @docids = <$fh>);
+close $fh;
+my %vocab;
+my @lengths = unpack 'l*', slurp('lengths.bin'); # Read the document lengths
+# Compute the average document length for BM25
+my $average_length = 0;
+foreach (@lengths) {
+	$average_length += $_;
+}
+$average_length /= scalar @lengths;
+open my $postings_fh, '<:raw', 'postings.bin' or die;
+
+# decode the vocabulary (unsigned byte length, string, '\0', 4 byte signed where, 4 signed byte size)
+my @vocab_raw = unpack '(C/axll)*', slurp('vocab.bin');
+while (my ($term, $where, $size) = splice(@vocab_raw, 0, 3)) {
+	$vocab{$term} = [$where, $size];
+}
+
+# Search (one query per line)
+while (<>) {
+	chomp;
+	my @query = split /\s/;
+
+	# If the first token is a number then assume a TREC query number, and skip it
+	my $query_id = '0';
+	if ($query[0] =~ /^\d+$/) {
+		$query_id = $query[0];
+		shift @query;
+	}
+
+	my @accumulators; # array of rsv values
+
+	foreach (@query) {
+		my $results = $vocab{$_};
+		next if not defined $results; # Does the term exist in the collection?
+
+		# Seek and read the postings list
+		my ($where, $size) = @{$results};
+		seek $postings_fh, $where, 0;
+		die $! if not defined read $postings_fh, (my $postings), $size;
+		my @postings = unpack 'l*', $postings;
+
+		# Compute the IDF component of BM25 as log(N/n).
+		my $idf = log(scalar @docids / (scalar @postings / 2));
+
+		# Process the postings list by simply adding the BM25 component for this document into the accumulators array
+		while (my ($docid, $freq) = splice(@postings, 0, 2)) {
+			my $rsv = $idf * (($freq * ($K1 + 1)) / ($freq + $K1 * (1 - $B + $B * ($lengths[$docid] / $average_length))));
+			if (not defined $accumulators[$docid]) {
+				$accumulators[$docid] = [$docid, $rsv];
+			} else {
+				${$accumulators[$docid]}[1] += $rsv;
+			}
+		}
+	}
+
+	# Sort the results list. Tie break on the document ID.
+	@accumulators = sort { @{$b}[1] <=> @{$a}[1] || @{$b}[0] <=> @{$a}[0] } @accumulators;
+
+	# Print the (at most) top 1000 documents in the results list in TREC eval format which is:
+	# query-id Q0 document-id rank score run-name
+	while (my ($i, $result) = each @accumulators) {
+		last if not defined $result;
+		last if $i == 1000;
+
+		my ($id, $freq) = @{$result};
+		printf "%s Q0 %s %d %.4f JASSjr\n", $query_id, $docids[$id], $i+1, $freq;
+	}
+}
+
+close $postings_fh; # clean up

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ So JASSjr is not as fast as JASSv2, and not quite as good at ranking as JASSv2, 
 | JASSjr_search.exs | Elixir source code to search engine |
 | JASSjr_index.rb | Ruby source code to indexer |
 | JASSjr_search.rb | Ruby source code to search engine |
+| JASSjr_index.pl | Perl source code to indexer |
+| JASSjr_search.pl | Perl source code to search engine |
 | GNUmakefile | GNU make makefile for macOS / Linux |
 | makefile | NMAKE makefile for Windows |
 | test_documents.xml | Example of how documents should be layed out for indexing | 


### PR DESCRIPTION
Adds a Perl implementation of JASSjr to go alongside the others.

This is a direct copy of the Ruby version with minor changes due to language differences

I have verified the output is the same through the following comparisons:
* docids.bin is the exact same
* lengths.bin is the exact same
* vocab.bin is the same size (it is stored in a different order)
* postings.bin is the same size (it is stored in a different order)
* execute an example query and compare the output is the exact same

Here are some example timings for the various versions on my machine:
| | Time to index (s) | Time for one query (s) | Time for 50 queries (s) |
| - | - | - | - |
| C++ | 15 | 0.35 | 3.90 |
| Java | 18 | 0.33 | 1.10 |
| Python | 74 | 0.85 | 2.80 |
| JavaScript | 35 |  0.75 | 3.80 |
| Elixir | 125 | 0.85 | 2.20 |
| Ruby | 160 | 2.30 | 62.5 |
| Perl | 115 | 0.90 | 3.60 |