### PR TITLE
JASSjr in Go

### DIFF
--- a/JASSjr_index.go
+++ b/JASSjr_index.go
@@ -1,0 +1,264 @@
+/*
+	JASSjr_index.go
+	---------------
+	Copyright (c) 2024 Vaughan Kitchen
+	Minimalistic BM25 search engine.
+*/
+
+package main
+
+import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"strings"
+)
+
+func check(e error) {
+	if e != nil {
+		panic(e)
+	}
+}
+
+func isAlpha(c byte) bool {
+	return ('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z')
+}
+
+func isDigit(c byte) bool {
+	return '0' <= c && c <= '9'
+}
+
+func isAlnum(c byte) bool {
+	return isAlpha(c) || isDigit(c)
+}
+
+/*
+Struct posting
+--------------
+*/
+type posting struct {
+	d, tf int32
+}
+
+/*
+Struct lexer
+------------
+*/
+type lexer struct {
+	buffer  []byte
+	current int
+}
+
+/*
+lexer.getNext()
+------------
+One-character lookahead lexical analyser
+*/
+func (l *lexer) getNext() *string {
+	/*
+		Skip over whitespace and punctuation (but not XML tags)
+	*/
+	for l.current < len(l.buffer) && !isAlnum(l.buffer[l.current]) && l.buffer[l.current] != '<' {
+		l.current++
+	}
+
+	/*
+		A token is either an XML tag '<'..'>' or a sequence of alpha-numerics.
+	*/
+	start := l.current
+	if l.current >= len(l.buffer) {
+		return nil
+	} else if isAlnum(l.buffer[l.current]) {
+		for l.current < len(l.buffer) && (isAlnum(l.buffer[l.current]) || l.buffer[l.current] == '-') {
+			l.current++
+		}
+	} else if l.buffer[l.current] == '<' {
+		for l.current++; l.current < len(l.buffer) && l.buffer[l.current-1] != '>'; l.current++ {
+			/* do nothing */
+		}
+	}
+	/*
+		Copy and return the token
+	*/
+	result := string(l.buffer[start:l.current])
+	return &result
+}
+
+/*
+main()
+------
+Simple indexer for TREC WSJ collection
+*/
+func main() {
+	vocab := make(map[string][]posting)
+	docIds := make([]string, 0)
+	lengthVector := make([]int32, 0)
+
+	var docId int32 = -1
+	var documentLength int32 = 0
+
+	/*
+		Make sure we have one parameter, the filename
+	*/
+	if len(os.Args) != 2 {
+		fmt.Println("Usage: ", os.Args[0], " <infile.xml>")
+		os.Exit(0)
+	}
+
+	fh, err := os.Open(os.Args[1])
+	check(err)
+	defer fh.Close()
+
+	scanner := bufio.NewScanner(fh)
+	pushNext := false
+	for scanner.Scan() {
+		lex := lexer{scanner.Bytes(), 0}
+		for token := lex.getNext(); token != nil; token = lex.getNext() {
+			token := *token
+			if token == "<DOC>" {
+				/*
+					Save the previous document length
+				*/
+				if docId != -1 {
+					lengthVector = append(lengthVector, documentLength)
+				}
+
+				/*
+					Move on to the next document
+				*/
+				docId++
+				documentLength = 0
+
+				if docId%1000 == 0 {
+					fmt.Println(docId, "documents indexed")
+				}
+			}
+
+			/*
+				if the last token we saw was a <DOCNO> then the next token is the primary key
+			*/
+			if pushNext {
+				docIds = append(docIds, token)
+				pushNext = false
+			}
+			if token == "<DOCNO>" {
+				pushNext = true
+			}
+
+			/*
+				Don't index XML tags
+			*/
+			if strings.HasPrefix(token, "<") {
+				continue
+			}
+
+			/*
+				lower case the string
+			*/
+			token = strings.ToLower(token)
+
+			/*
+				truncate any long tokens at 255 charactes (so that the length can be stored first and in a single byte)
+			*/
+			if len(token) > 0xFF {
+				token = token[:0xFF+1]
+			}
+
+			/*
+				add the posting to the in-memory index
+			*/
+			list, ok := vocab[token]
+			if !ok {
+				newList := make([]posting, 0)
+				newList = append(newList, posting{docId, 1})
+				vocab[token] = newList // if the term isn't in the vocab yet
+			} else if list[len(list)-1].d != docId {
+				vocab[token] = append(list, posting{docId, 1}) // if the docno for this occurence hasn't changed the increase tf
+			} else {
+				list[len(list)-1].tf++ // else create a new <d,tf> pair.
+			}
+
+			/*
+				compute the document length
+			*/
+			documentLength++
+		}
+	}
+	check(scanner.Err())
+
+	/*
+		Save the final document length
+	*/
+	lengthVector = append(lengthVector, documentLength)
+
+	/*
+		tell the user we've got to the end of parsing
+	*/
+	fmt.Println("Indexed", docId+1, "documents. Serialing...")
+
+	/*
+		store the primary keys
+	*/
+	docIdFile, err := os.Create("docids.bin")
+	check(err)
+	defer docIdFile.Close()
+	docIdWriter := bufio.NewWriter(docIdFile)
+	defer docIdWriter.Flush()
+	for _, primaryKey := range docIds {
+		docIdWriter.WriteString(primaryKey + "\n")
+	}
+
+	/*
+		serialise the in-memory index to disk
+	*/
+	postingsFile, err := os.Create("postings.bin")
+	check(err)
+	defer postingsFile.Close()
+	postingsWriter := bufio.NewWriter(postingsFile)
+	defer postingsWriter.Flush()
+	vocabFile, err := os.Create("vocab.bin")
+	check(err)
+	defer vocabFile.Close()
+	vocabWriter := bufio.NewWriter(vocabFile)
+	defer vocabWriter.Flush()
+
+	var where uint32 = 0
+	byteBuffer := make([]byte, 4)
+	for term, postings := range vocab {
+		/*
+			write the postings list to one file
+		*/
+		err = binary.Write(postingsWriter, binary.NativeEndian, postings)
+		check(err)
+
+		/*
+			write the vocabulary to a second file (one byte length, string, '\0', 4 byte where, 4 byte size)
+		*/
+		err = vocabWriter.WriteByte(byte(len(term)))
+		check(err)
+		_, err = vocabWriter.WriteString(term)
+		check(err)
+		err = vocabWriter.WriteByte(0)
+		check(err)
+		binary.NativeEndian.PutUint32(byteBuffer, where)
+		_, err = vocabWriter.Write(byteBuffer)
+		check(err)
+		binary.NativeEndian.PutUint32(byteBuffer, uint32(len(postings)*8))
+		_, err = vocabWriter.Write(byteBuffer)
+		check(err)
+
+		where += uint32(len(postings) * 8)
+	}
+
+	/*
+		store the document lengths
+	*/
+	docLengthsFile, err := os.Create("lengths.bin")
+	check(err)
+	defer docLengthsFile.Close()
+	docLengthsWriter := bufio.NewWriter(docLengthsFile)
+	defer docLengthsWriter.Flush()
+	err = binary.Write(docLengthsWriter, binary.NativeEndian, lengthVector)
+	check(err)
+}

--- a/JASSjr_search.go
+++ b/JASSjr_search.go
@@ -120,16 +120,12 @@ func main() {
 	for stdin.Scan() {
 		/*
 		  Zero the accumulator array.
+		  Re-initialise the rsv pointers. Saving us
+		  from using a slow comparator during sort
 		*/
 		for i := range rsv {
 			rsv[i] = 0
-		}
-		/*
-		  Re-initialise the rsv pointers
-		  this saves us from using a slow sort comparator
-		*/
-		for i := len(rsvPointers) - 1; i >= 0; i-- {
-			rsvPointers[i] = i
+			rsvPointers[i] = len(rsvPointers) - 1 - i
 		}
 		var queryId int = 0
 		for i, token := range strings.Fields(stdin.Text()) {

--- a/JASSjr_search.go
+++ b/JASSjr_search.go
@@ -113,9 +113,6 @@ func main() {
 		  Set up the rsv pointers
 	*/
 	rsvPointers := make([]int, documentsInCollection) // pointers to each member of rsv[] so that we can sort
-	for i := range rsv {
-		rsvPointers[i] = i
-	}
 
 	/*
 		  Search (one query per line)
@@ -127,6 +124,13 @@ func main() {
 		*/
 		for i := range rsv {
 			rsv[i] = 0
+		}
+		/*
+			Re-initialise the rsv pointers
+			this saves us from using a slow sort comparator
+		*/
+		for i := len(rsvPointers)-1; i >= 0; i-- {
+			rsvPointers[i] = i
 		}
 		var queryId int = 0
 		for i, token := range strings.Fields(stdin.Text()) {
@@ -181,12 +185,8 @@ func main() {
 		/*
 			Sort the results list
 		*/
-		slices.SortFunc(rsvPointers, func(a, b int) int {
-			if res := cmp.Compare(rsv[b], rsv[a]); res == 0 {
-				return b - a
-			} else {
-				return res
-			}
+		slices.SortStableFunc(rsvPointers, func(a, b int) int {
+			return cmp.Compare(rsv[b], rsv[a])
 		})
 
 		/*

--- a/JASSjr_search.go
+++ b/JASSjr_search.go
@@ -1,0 +1,206 @@
+/*
+	JASSjr_search.go
+	----------------
+	Copyright (c) 2024 Vaughan Kitchen
+	Minimalistic BM25 search engine.
+*/
+
+package main
+
+import (
+	"strconv"
+	"slices"
+	"encoding/binary"
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"bytes"
+	"math"
+	"cmp"
+)
+
+/*
+	Constants
+	---------
+*/
+const k1 = 0.9 // BM25 k1 parameter
+const b = 0.4 // BM25 b parameter
+
+/*
+	Struct vocabEntry
+	-----------------
+*/
+type vocabEntry struct {
+	where, size int32 // where on the disk and how large (in bytes) is the postings list?
+}
+
+func check(e error) {
+	if e != nil {
+		panic(e)
+	}
+}
+
+/*
+	main()
+	------
+	Simple search engine ranking on BM25.
+*/
+func main() {
+	/*
+		  Read the document lengths
+	*/
+	lengthsAsBytes, err := os.ReadFile("lengths.bin")
+	check(err)
+	lengthVector := make([]int32, len(lengthsAsBytes) / 4)
+	err = binary.Read(bytes.NewReader(lengthsAsBytes), binary.NativeEndian, lengthVector)
+	check(err)
+
+	/*
+		  Compute the average document length for BM25
+	*/
+	documentsInCollection := len(lengthVector)
+	var averageDocumentLength float64 = 0
+	for _, which := range lengthVector {
+		averageDocumentLength += float64(which)
+	}
+	averageDocumentLength /= float64(documentsInCollection)
+
+	/*
+		  Read the primary keys
+	*/
+	primaryKeysAsBytes, err := os.ReadFile("docids.bin")
+	check(err)
+	// This isn't performant for large files. Prefer bufio.Scanner there
+	// But for small files like what we have here it is faster
+	primaryKeys := strings.Split(string(primaryKeysAsBytes), "\n")
+
+	/*
+		  Open the postings list file
+	*/
+	postingsFile, err := os.Open("postings.bin")
+	check(err)
+
+
+	/*
+		  Build the vocabulary in memory
+	*/
+	dictionary := make(map[string]vocabEntry) // the vocab
+	vocabAsBytes, err := os.ReadFile("vocab.bin")
+	check(err)
+	for offset := 0; offset < len(vocabAsBytes); {
+		strLength := int(vocabAsBytes[offset])
+		offset += 1
+
+		term := string(vocabAsBytes[offset:offset+strLength])
+		offset += strLength + 1 // read the '\0' string terminator
+
+		where := binary.NativeEndian.Uint32(vocabAsBytes[offset:])
+		offset += 4
+		size := binary.NativeEndian.Uint32(vocabAsBytes[offset:])
+		offset += 4
+
+		// TODO pointer type?
+		dictionary[term] = vocabEntry{int32(where), int32(size)}
+	}
+
+	/*
+		  Allocate buffers
+	*/
+	rsv := make([]float64, documentsInCollection) // array of rsv values
+
+	/*
+		  Set up the rsv pointers
+	*/
+	rsvPointers := make([]int, documentsInCollection) // pointers to each member of rsv[] so that we can sort
+	for i := range rsv {
+		rsvPointers[i] = i
+	}
+
+	/*
+		  Search (one query per line)
+	*/
+	stdin := bufio.NewScanner(os.Stdin)
+	for stdin.Scan() {
+		/*
+			  Zero the accumulator array.
+		*/
+		for i := range rsv {
+			rsv[i] = 0
+		}
+		var queryId int = 0
+		for i, token := range strings.Fields(stdin.Text()) {
+			/*
+				If the first token is a number then assume a TREC query number, and skip it
+			*/
+			if i == 0 {
+				if num, err := strconv.Atoi(token); err == nil {
+					queryId = num
+					continue
+				}
+			}
+
+			/*
+				  Does the term exist in the collection?
+			*/
+			termDetails, ok := dictionary[token]
+			if !ok {
+				continue
+			}
+
+			/*
+				Seek and read the postings list
+			*/
+			currentListAsBytes := make([]byte, termDetails.size)
+			_, err := postingsFile.ReadAt(currentListAsBytes, int64(termDetails.where))
+			check(err)
+			currentList := make([]int32, len(currentListAsBytes) / 4)
+			err = binary.Read(bytes.NewReader(currentListAsBytes), binary.NativeEndian, currentList)
+			check(err)
+			postings := len(currentListAsBytes) / 8
+
+			/*
+				Compute the IDF component of BM25 as log(N/n).
+				if IDF == 0 then don't process this postings list as the BM25 contribution of this term will be zero.
+			*/
+			if documentsInCollection == postings {
+				continue
+			}
+
+			idf := math.Log(float64(documentsInCollection) / float64(postings));
+
+			/*
+				Process the postings list by simply adding the BM25 component for this document into the accumulators array
+			*/
+			for i := 0; i < len(currentList); i += 2 {
+				d := currentList[i]
+				tf := float64(currentList[i+1])
+				rsv[d] += idf * ((tf * (k1 + 1)) / (tf + k1 * (1 - b + b * (float64(lengthVector[d]) / averageDocumentLength))));
+			}
+		}
+		/*
+			Sort the results list
+		*/
+		slices.SortFunc(rsvPointers, func(a, b int) int {
+			if res := cmp.Compare(rsv[b], rsv[a]); res == 0 {
+				return b - a
+			} else {
+				return res
+			}
+		})
+
+		/*
+			Print the (at most) top 1000 documents in the results list in TREC eval format which is:
+			query-id Q0 document-id rank score run-name
+		*/
+		for i, r := range rsvPointers {
+			if rsv[r] == 0 || i == 1000 {
+				break
+			}
+			fmt.Printf("%d Q0 %s %d %.4f JASSjr\n", queryId, primaryKeys[rsvPointers[i]], i+1, rsv[r])
+		}
+	}
+	if err := stdin.Err(); err != nil {
+		panic(err)
+	}
+}

--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ and then run with
 
 	ruby --yjit JASSjr_search.rb
 
+## Go ##
+To index use
+
+    go run JASSjr_index.go <filename>
+
+To search use
+
+    go run JASSjr_search.go
+
+Alternatively `go build` can be used to produce binaries. Though the names of these will conflict with the C++ versions
+
 ## Other ##
 The interpreted languages include a shebang and can be executed directly e.g.
 
@@ -139,6 +150,8 @@ So JASSjr is not as fast as JASSv2, and not quite as good at ranking as JASSv2, 
 | JASSjr_search.rb | Ruby source code to search engine |
 | JASSjr_index.pl | Perl source code to indexer |
 | JASSjr_search.pl | Perl source code to search engine |
+| JASSjr_index.go | Go source code to indexer |
+| JASSjr_search.go | Go source code to search engine |
 | GNUmakefile | GNU make makefile for macOS / Linux |
 | makefile | NMAKE makefile for Windows |
 | test_documents.xml | Example of how documents should be layed out for indexing | 


### PR DESCRIPTION
Adds a Go implementation of JASSjr to go alongside the others.

This is a direct copy of the Java version with minor changes due to language differences

I have verified the output is the same through the following comparisons:
* docids.bin is the exact same
* lengths.bin is the exact same
* vocab.bin is the same size (it is stored in a different order)
* postings.bin is the same size (it is stored in a different order)
* execute an example query and compare the output is the exact same

Here are some example timings for the various versions on my machine:
| | Time to index (s) | Time for one query (s) | Time for 50 queries (s) |
| - | - | - | - |
| C++ | 15 | 0.35 | 3.90 |
| Java | 18 | 0.33 | 1.10 |
| Python | 74 | 0.85 | 2.80 |
| JavaScript | 35 |  0.75 | 3.80 |
| Elixir | 125 | 0.85 | 2.20 |
| Ruby | 160 | 2.30 | 62.5 |
| Perl | 115 | 0.90 | 3.60 |
| Go | 18 | 0.25 | 0.67 |