### PR TITLE
JASSjr in Raku

### DIFF
--- a/JASSjr_index.raku
+++ b/JASSjr_index.raku
@@ -19,7 +19,7 @@ my $push_next = False; # is the next token the primary key?
 for @*ARGS[0].IO.lines -> $line {
 	# A token is either an XML tag '<'..'>' or a sequence of alpha-numerics.
   	# TREC <DOCNO> primary keys have a hyphen in them
-	for $line.match(/<[a..zA..Z1..9]><[a..zA..Z0..9-]>* | '<'<-[>]>*'>'/, :global) {
+	for $line.match(/<[a..zA..Z0..9]><[a..zA..Z0..9-]>* | '<'<-[>]>*'>'/, :global) {
 		my $token = $_.Str;
 		# If we see a <DOC> tag then we're at the start of the next document
 		if $token eq '<DOC>' {

--- a/JASSjr_index.raku
+++ b/JASSjr_index.raku
@@ -1,0 +1,117 @@
+#!/usr/bin/env raku
+
+# Copyright (c) 2024 Vaughan Kitchen
+# Minimalistic BM25 search engine.
+
+if @*ARGS.elems != 1 {
+	say("Usage: $*PROGRAM-NAME <infile.xml>");
+	exit;
+}
+
+my %vocab; # the in-memory index
+my @doc_ids; # the primary keys
+my @length_vector; # hold the length of each document
+
+my $docid = -1;
+my $document_length = 0;
+my $push_next = False; # is the next token the primary key?
+
+for @*ARGS[0].IO.lines -> $line {
+	# A token is either an XML tag '<'..'>' or a sequence of alpha-numerics.
+  	# TREC <DOCNO> primary keys have a hyphen in them
+	for $line.match(/<[a..zA..Z1..9]><[a..zA..Z0..9-]>* | '<'<-[>]>*'>'/, :global) {
+		my $token = $_.Str;
+		# If we see a <DOC> tag then we're at the start of the next document
+		if $token eq '<DOC>' {
+			# Save the previous document length
+			@length_vector.push($document_length) if $docid != -1;
+			# Move on to the next document
+			$docid += 1;
+			$document_length = 0;
+			say("$docid documents indexed") if $docid %% 1000;
+		}
+		# if the last token we saw was a <DOCNO> then the next token is the primary key
+		if $push_next {
+			@doc_ids.push($token);
+			$push_next = False;
+		}
+		$push_next = True if $token eq '<DOCNO>';
+
+		# Don't index XML tags
+		next if $token.starts-with('<');
+
+		# lower case the string
+		$token = $token.lc;
+
+		# truncate any long tokens at 255 charactes (so that the length can be stored first and in a single byte)
+		$token = $token.substr(0..255);
+
+		# add the posting to the in-memory index
+		if %vocab{$token}:!exists {
+			%vocab{$token} = [$docid, 1];
+		} elsif %vocab{$token}[*-2] != $docid {
+			%vocab{$token}.push($docid, 1);
+		} else {
+			%vocab{$token}[*-1] += 1;
+		}
+
+		# Compute the document length
+		$document_length += 1;
+	}
+}
+
+# If we didn't index any documents then we're done.
+exit if $docid == -1;
+
+# Save the final document length
+@length_vector.push($document_length);
+
+# tell the user we've got to the end of parsing
+say("Indexed {$docid+1} documents. Serialising...");
+
+# store the primary keys
+my $docids_fh = open('docids.bin', :w);
+for @doc_ids -> $docid {
+	$docids_fh.say($docid);
+}
+
+my $postings_fh = open('postings.bin', :w, :bin);
+my $vocab_fh = open('vocab.bin', :w, :bin);
+
+my $buffer = Buf.new;
+for %vocab.kv -> $term, @postings {
+	$buffer.reallocate(0);
+
+	# write the postings list to one file
+	my $where = $postings_fh.tell;
+	for @postings {
+		$buffer.write-int32(0, $_);
+		$postings_fh.write($buffer);
+	}
+
+	$buffer.reallocate(0);
+	# write the vocabulary to a second file (one byte length, string, '\0', 4 byte where, 4 byte size)
+	$buffer.write-uint8(0, $term.chars);
+	$vocab_fh.write($buffer);
+	$vocab_fh.write($term.encode);
+	$buffer.reallocate(0);
+	$buffer.write-uint8(0, 0);
+	$buffer.write-int32(1, $where);
+	$buffer.write-int32(5, @postings.elems * 4);
+	$vocab_fh.write($buffer);
+}
+
+$buffer.reallocate(0);
+
+# store the document lengths
+my $lengths_fh = open('lengths.bin', :w, :bin);
+for @length_vector {
+	$buffer.write-int32(0, $_);
+	$lengths_fh.write($buffer);
+}
+
+# clean up
+$docids_fh.close;
+$postings_fh.close;
+$vocab_fh.close;
+$lengths_fh.close;

--- a/JASSjr_index.raku
+++ b/JASSjr_index.raku
@@ -26,7 +26,7 @@ for @*ARGS[0].IO.lines -> $line {
 			# Save the previous document length
 			@length_vector.push($document_length) if $docid != -1;
 			# Move on to the next document
-			$docid += 1;
+			$docid++;
 			$document_length = 0;
 			say("$docid documents indexed") if $docid %% 1000;
 		}
@@ -56,7 +56,7 @@ for @*ARGS[0].IO.lines -> $line {
 		}
 
 		# Compute the document length
-		$document_length += 1;
+		$document_length++;
 	}
 }
 

--- a/JASSjr_index.raku
+++ b/JASSjr_index.raku
@@ -44,7 +44,7 @@ for @*ARGS[0].IO.lines -> $line {
 		$token = $token.lc;
 
 		# truncate any long tokens at 255 charactes (so that the length can be stored first and in a single byte)
-		$token = $token.substr(0..255);
+		$token = $token.substr(0, 256);
 
 		# add the posting to the in-memory index
 		if %vocab{$token}:!exists {

--- a/JASSjr_index.raku
+++ b/JASSjr_index.raku
@@ -47,12 +47,12 @@ for @*ARGS[0].IO.lines -> $line {
 		$token = $token.substr(0, 256);
 
 		# add the posting to the in-memory index
-		if %vocab{$token}:!exists {
-			%vocab{$token} = [$docid, 1];
-		} elsif %vocab{$token}[*-2] != $docid {
-			%vocab{$token}.push($docid, 1);
+		%vocab{$token} = [] if %vocab{$token}:!exists;
+		my @postings_list := %vocab{$token};
+		if @postings_list.elems == 0 || @postings_list[*-2] != $docid {
+			@postings_list.push($docid, 1);
 		} else {
-			%vocab{$token}[*-1] += 1;
+			@postings_list[*-1]++;
 		}
 
 		# Compute the document length

--- a/JASSjr_search.raku
+++ b/JASSjr_search.raku
@@ -1,0 +1,85 @@
+#!/usr/bin/env raku
+
+# Copyright (c) 2024 Vaughan Kitchen
+# Minimalistic BM25 search engine.
+
+constant $k1 = 0.9; # BM25 k1 parameter
+constant $b = 0.4; # BM25 b parameter
+
+# Read the primary_keys
+my @doc_ids = slurp('docids.bin').split("\n");
+
+# Read the document lengths
+my $doc_lengths_raw = slurp('lengths.bin', :bin);
+my @doc_lengths = (0, 4 ...^ $doc_lengths_raw.bytes).map: { $doc_lengths_raw.read-int32($_) };
+my $average_length = @doc_lengths.sum / @doc_lengths.elems;
+
+# Open the postings list file
+my $postings_fh = open('postings.bin');
+
+# decode the vocabulary (unsigned byte length, string, '\0', 4 byte signed where, 4 signed byte size)
+my %vocab;
+
+my $vocab_raw = slurp('vocab.bin', :bin);
+my $offset = 0;
+
+while $offset < $vocab_raw.bytes {
+	my $length = $vocab_raw[$offset].Int;
+	$offset += 1;
+
+	my $term = $vocab_raw.subbuf($offset, $length).decode('ascii');
+	$offset += $length + 1; # Null terminated
+
+	my $where = $vocab_raw.read-int32($offset);
+	my $size = $vocab_raw.read-int32($offset+4);
+	$offset += 8;
+
+	%vocab{$term} = [$where, $size];
+}
+
+# Search (one query per line)
+loop {
+	my $query = prompt;
+	last if !$query;
+
+	my @accumulators = [0, 0] xx @doc_ids.elems;
+
+	my $query_id = 0;
+	my @query = $query.words;
+
+	# If the first token is a number then assume a TREC query number, and skip it
+	if @query[0].Int !~~ Failure {
+		$query_id = @query.shift.Int;
+	}
+
+	for @query -> $term {
+		# Does the term exist in the collection?
+		next if %vocab{$term}:!exists;
+
+		my ($offset, $size) = %vocab{$term};
+
+		# Seek and read the postings list
+		$postings_fh.seek($offset);
+		my $postings_raw = $postings_fh.read($size);
+		my @postings = (0, 4 ...^ $postings_raw.bytes).map: { $postings_raw.read-int32($_) };
+
+		# Compute the IDF component of BM25 as log(N/n).
+		my $idf = log(@doc_ids.elems / (@postings.elems / 2));
+
+		# Process the postings list by simply adding the BM25 component for this document into the accumulators array
+		for @postings -> $docid, $tf {
+			my $rsv = $idf * (($tf * ($k1 + 1)) / ($tf + $k1 * (1 - $b + $b * (@doc_lengths[$docid] / $average_length))));
+			@accumulators[$docid][0] += $rsv;
+			@accumulators[$docid][1] = $docid;
+		}
+	}
+
+	# Sort the results list. Tie break on the document ID.
+	@accumulators = @accumulators.sort.reverse;
+	
+	# Print the (at most) top 1000 documents in the results list in TREC eval format which is:
+	# query-id Q0 document-id rank score run-name
+	for @accumulators.grep({ $_[0] > 0 || last }).head(1000).kv -> $i, ($rsv, $docid) {
+		printf("%d Q0 %s %d %.4f JASSjr\n", $query_id, @doc_ids[$docid], $i+1, $rsv);
+	}
+}

--- a/JASSjr_search.raku
+++ b/JASSjr_search.raku
@@ -7,7 +7,7 @@ constant $k1 = 0.9; # BM25 k1 parameter
 constant $b = 0.4; # BM25 b parameter
 
 # Read the primary_keys
-my @doc_ids = slurp('docids.bin').split("\n");
+my @doc_ids = 'docids.bin'.IO.lines;
 
 # Read the document lengths
 my $doc_lengths_raw = slurp('lengths.bin', :bin);

--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ So JASSjr is not as fast as JASSv2, and not quite as good at ranking as JASSv2, 
 | JASSjr_search.pl | Perl source code to search engine |
 | JASSjr_index.go | Go source code to indexer |
 | JASSjr_search.go | Go source code to search engine |
+| JASSjr_index.raku | Raku source code to indexer |
+| JASSjr_search.raku | Raku source code to search engine |
 | GNUmakefile | GNU make makefile for macOS / Linux |
 | makefile | NMAKE makefile for Windows |
 | test_documents.xml | Example of how documents should be layed out for indexing | 


### PR DESCRIPTION
Adds a Raku (formerly Perl6) implementation of JASSjr to go alongside the others.

This is a direct copy of the Ruby version with minor changes due to language differences

I have verified the output is the same through the following comparisons:
* docids.bin is the exact same
* lengths.bin is the exact same
* vocab.bin is the same size (it is stored in a different order)
* postings.bin is the same size (it is stored in a different order)
* execute an example query and compare the output is the exact same

Here are some example timings for the various versions on my machine:
| | Time to index (s) | Time for one query (s) | Time for 50 queries (s) |
| - | - | - | - |
| C++ | 15 | 0.35 | 3.90 |
| Java | 18 | 0.33 | 1.10 |
| Python | 74 | 0.85 | 2.80 |
| JavaScript | 35 |  0.75 | 3.80 |
| Elixir | 125 | 0.85 | 2.20 |
| Ruby | 160 | 2.30 | 62.5 |
| Perl | 115 | 0.90 | 3.60 |
| Go | 18 | 0.25 | 0.67 |
| Raku | 140mins | 8 | 170 |