### PR TITLE
JASSjr in Nim

### DIFF
--- a/JASSjr_index.nim
+++ b/JASSjr_index.nim
@@ -22,13 +22,14 @@ var length_vector: seq[int32] # hold the length of each document
 
 # A token is either an XML tag '<'..'>' or a sequence of alpha-numerics.
 # TREC <DOCNO> primary keys have a hyphen in them
+let lexer = re"[a-zA-Z0-9][a-zA-Z0-9-]*|<[^>]*>"
 
 var docid: int32 = -1
 var document_length: int32 = 0
 var push_next = false # is the next token the primary key?
 
 for line in lines(commandLineParams()[0]):
-  for token in line.findall(re"[a-zA-Z0-9][a-zA-Z0-9-]*|<[^>]*>"):
+  for token in line.findall(lexer):
     # If we see a <DOC> tag then we're at the start of the next document
     if token == "<DOC>":
       # Save the previous document length

--- a/JASSjr_index.nim
+++ b/JASSjr_index.nim
@@ -1,0 +1,30 @@
+#!/usr/bin/env -S nim r --hints:off
+
+# Copyright (c) 2024 Vaughan Kitchen
+# Minimalistic BM25 search engine.
+
+import std/cmdline
+import std/os
+import std/re
+import std/strformat
+import std/tables
+
+# Make sure we have one parameter, the filename
+if paramCount() != 1:
+  echo(fmt"Usage: { getAppFilename() } <infile.xml>")
+  quit()
+
+var vocab = initTable[string, seq[int32]]() # the in-memory index
+var doc_ids: seq[string] # the primary keys
+var length_vector: seq[int32] # hold the length of each document
+
+# A token is either an XML tag '<'..'>' or a sequence of alpha-numerics.
+# TREC <DOCNO> primary keys have a hyphen in them
+
+var docid = -1
+var document_length = 0
+var push_next = false # is the next token the primary key?
+
+for line in lines(commandLineParams()[0]):
+  for token in line.findall(re"[a-zA-Z0-9][a-zA-Z0-9-]*|<[^>]*>"):
+    echo(token)

--- a/JASSjr_index.nim
+++ b/JASSjr_index.nim
@@ -6,7 +6,9 @@
 import std/cmdline
 import std/os
 import std/re
+import std/streams
 import std/strformat
+import std/strutils
 import std/tables
 
 # Make sure we have one parameter, the filename
@@ -21,10 +23,89 @@ var length_vector: seq[int32] # hold the length of each document
 # A token is either an XML tag '<'..'>' or a sequence of alpha-numerics.
 # TREC <DOCNO> primary keys have a hyphen in them
 
-var docid = -1
-var document_length = 0
+var docid: int32 = -1
+var document_length: int32 = 0
 var push_next = false # is the next token the primary key?
 
 for line in lines(commandLineParams()[0]):
   for token in line.findall(re"[a-zA-Z0-9][a-zA-Z0-9-]*|<[^>]*>"):
-    echo(token)
+    # If we see a <DOC> tag then we're at the start of the next document
+    if token == "<DOC>":
+      # Save the previous document length
+      if docid != -1:
+        length_vector.add(document_length)
+      # Move on to the next document
+      docid += 1
+      document_length = 0
+      if docid mod 1000 == 0:
+        echo(fmt"{docid} documents indexed")
+    # if the last token we saw was a <DOCNO> then the next token is the primary key
+    if push_next:
+      doc_ids.add(token)
+      push_next = false
+    if token == "<DOCNO>":
+      push_next = true
+    # Don't index XML tags
+    if token[0] == '<':
+      continue
+
+    # lower case the string
+    var token2 = token.toLowerAscii()
+
+    # truncate any long tokens at 255 charactes (so that the length can be stored first and in a single byte)
+    if len(token2) > 255:
+      token2 = token2[0..<255]
+
+    # add the posting to the in-memory index
+    if not (token2 in vocab):
+      vocab[token2] = newSeq[int32]()
+
+    let postings_list = addr(vocab[token2])
+    if len(postings_list[]) == 0 or postings_list[][^2] != docid:
+      postings_list[].add(docid)
+      postings_list[].add(1)
+    else:
+      postings_list[][^1] += 1
+
+    # Compute the document length
+    document_length += 1
+
+# If we didn't index any documents then we're done.
+if docid == -1:
+  quit()
+
+# Save the final document length
+length_vector.add(document_length)
+
+# tell the user we've got to the end of parsing
+echo(fmt"Indexed { docid + 1 } documents. Serialising...")
+
+# store the primary keys
+let docids_fh = open("docids.bin", fmWrite)
+for docid in doc_ids:
+  docids_fh.writeLine(docid)
+
+# serialise the in-memory index to disk
+let postings_strm = newFileStream("postings.bin", fmWrite)
+let vocab_strm = newFileStream("vocab.bin", fmWrite)
+for term, postings in vocab.pairs():
+  # write the postings list to one file
+  let where = postings_strm.getPosition()
+  postings_strm.writeData(addr(postings[0]), len(postings) * sizeof(postings[0]))
+
+  # write the vocabulary to a second file (one byte length, string, '\0', 4 byte where, 4 byte size)
+  vocab_strm.write(uint8(len(term)))
+  vocab_strm.write(term)
+  vocab_strm.write('\0') # string is null terminated
+  vocab_strm.write(int32(where))
+  vocab_strm.write(int32(len(postings) * sizeof(postings[0])))
+
+# store the document lengths
+let doc_lengths_strm = newFileStream("lengths.bin", fmWrite)
+doc_lengths_strm.writeData(addr(length_vector[0]), len(length_vector) * sizeof(length_vector[0]))
+
+# clean up
+docids_fh.close()
+postings_strm.close()
+vocab_strm.close()
+doc_lengths_strm.close()

--- a/JASSjr_index.nim
+++ b/JASSjr_index.nim
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S nim r --hints:off
+#!/usr/bin/env -S nim r --hints:off -d:release
 
 # Copyright (c) 2024 Vaughan Kitchen
 # Minimalistic BM25 search engine.

--- a/JASSjr_search.nim
+++ b/JASSjr_search.nim
@@ -37,20 +37,33 @@ while not vocab_strm.atEnd:
 
 vocab_strm.close()
 
-let query = readLine(stdin).strip
-let (where, length) = vocab[query]
+try:
+  while true:
+    let query = readLine(stdin)
 
-postings.setLen(0)
+    let terms = query.splitWhitespace
 
-let postings_fh = open("postings.bin")
-postings_fh.setFilePos(where)
-let postings_strm = newFileStream(postings_fh)
+    for term in terms:
+      try:
+        let (where, length) = vocab[term]
 
-for i in 0 .. length:
-  let docid = postings_strm.readInt32
-  let tf = postings_strm.readInt32
-  postings.add((docid, tf))
+        postings.setLen(0)
 
-postings_strm.close() # strm owns fh
-for i, (docid, tf) in postings:
-   echo(fmt"0 Q0 {doc_ids[docid]} {i+1} {tf} JASSjr")
+        let postings_fh = open("postings.bin")
+        postings_fh.setFilePos(where)
+        let postings_strm = newFileStream(postings_fh)
+
+        for i in 0 .. length:
+          let docid = postings_strm.readInt32
+          let tf = postings_strm.readInt32
+          postings.add((docid, tf))
+
+        postings_strm.close() # strm owns fh
+        for i, (docid, tf) in postings:
+          if i == 10:
+            break
+          echo(fmt"0 Q0 {doc_ids[docid]} {i+1} {tf} JASSjr")
+      except KeyError:
+        discard
+except EOFError:
+  discard

--- a/JASSjr_search.nim
+++ b/JASSjr_search.nim
@@ -88,6 +88,6 @@ try:
     for i, (rsv, docid) in accumulators:
       if rsv == 0 or i == 10:
         break
-      echo(fmt"0 Q0 {doc_ids[docid]} {i+1} {rsv} JASSjr")
+      echo(fmt"0 Q0 {doc_ids[docid]} {i+1} {rsv:.4f} JASSjr")
 except EOFError:
   discard

--- a/JASSjr_search.nim
+++ b/JASSjr_search.nim
@@ -23,28 +23,34 @@ while not doc_lengths_strm.atEnd:
 doc_lengths_strm.close()
 
 var postings: seq[tuple[docid: int32, tf: int32]]
-let postings_strm = newFileStream("postings.bin", fmRead)
-
-while not postings_strm.atEnd:
-  let docid = postings_strm.readInt32
-  let tf = postings_strm.readInt32
-  postings.add((docid, tf))
-
-postings_strm.close()
 
 var vocab = initTable[string, tuple[where: int32, length: int32]]()
 let vocab_strm = newFileStream("vocab.bin", fmRead)
+
 while not vocab_strm.atEnd:
   let term_length = vocab_strm.readUint8
   let term = vocab_strm.readStr(int(term_length))
   discard vocab_strm.readUint8
   let where = vocab_strm.readInt32
   let length = vocab_strm.readInt32
-  vocab[term] = (where div 8, length div 8)
+  vocab[term] = (where, length div 8)
 
 vocab_strm.close()
 
 let query = readLine(stdin).strip
 let (where, length) = vocab[query]
-for i, (docid, tf) in postings[where..where+length-1]:
-  echo(fmt"0 Q0 {doc_ids[docid]} {i+1} {tf} JASSjr")
+
+postings.setLen(0)
+
+let postings_fh = open("postings.bin")
+postings_fh.setFilePos(where)
+let postings_strm = newFileStream(postings_fh)
+
+for i in 0 .. length:
+  let docid = postings_strm.readInt32
+  let tf = postings_strm.readInt32
+  postings.add((docid, tf))
+
+postings_strm.close() # strm owns fh
+for i, (docid, tf) in postings:
+   echo(fmt"0 Q0 {doc_ids[docid]} {i+1} {tf} JASSjr")

--- a/JASSjr_search.nim
+++ b/JASSjr_search.nim
@@ -38,13 +38,11 @@ while not vocab_strm.atEnd():
   discard vocab_strm.readUint8()
   let where = vocab_strm.readInt32()
   let length = vocab_strm.readInt32()
-  vocab[term] = (where, length div 8)
+  vocab[term] = (where, length)
 
 vocab_strm.close()
 
 var accumulators = newSeq[(float, int)](len(doc_ids))
-for i, _ in accumulators:
-  accumulators[i][1] = i
 
 try:
   while true:
@@ -63,7 +61,7 @@ try:
       discard
 
     for i, _ in accumulators:
-      accumulators[i][0] = 0
+      accumulators[i] = (0, i)
 
     for term in terms:
       try:
@@ -76,7 +74,7 @@ try:
 
         let postings_strm = newFileStream(postings_fh)
 
-        for i in 0 .. length:
+        for i in 0 .. length div 8 - 1:
           let docid = postings_strm.readInt32()
           let tf = postings_strm.readInt32()
           postings.add((docid, tf))
@@ -94,7 +92,7 @@ try:
     accumulators.sort(Descending)
 
     for i, (rsv, docid) in accumulators:
-      if rsv == 0 or i == 10:
+      if rsv == 0 or i == 1000:
         break
       echo(fmt"{query_id} Q0 {doc_ids[docid]} {i+1} {rsv:.4f} JASSjr")
 except EOFError:

--- a/JASSjr_search.nim
+++ b/JASSjr_search.nim
@@ -1,0 +1,50 @@
+#!/usr/bin/env -S nim r --hints:off
+
+# Copyright (c) 2024 Vaughan Kitchen
+# Minimalistic BM25 search engine.
+
+import std/streams
+import std/strformat
+import std/strutils
+import std/tables
+
+let k1 = 0.9 # BM25 k1 parameter
+let b = 0.4 # BM25 b parameter
+
+let doc_ids = readFile("docids.bin").strip.splitLines
+
+var doc_lengths: seq[int32]
+let doc_lengths_strm = newFileStream("lengths.bin", fmRead)
+
+while not doc_lengths_strm.atEnd:
+  let length = doc_lengths_strm.readInt32
+  doc_lengths.add(length)
+
+doc_lengths_strm.close()
+
+var postings: seq[tuple[docid: int32, tf: int32]]
+let postings_strm = newFileStream("postings.bin", fmRead)
+
+while not postings_strm.atEnd:
+  let docid = postings_strm.readInt32
+  let tf = postings_strm.readInt32
+  postings.add((docid, tf))
+
+postings_strm.close()
+
+var vocab = initTable[string, tuple[where: int32, length: int32]]()
+let vocab_strm = newFileStream("vocab.bin", fmRead)
+while not vocab_strm.atEnd:
+  let term_length = vocab_strm.readUint8
+  let term = vocab_strm.readStr(int(term_length))
+  discard vocab_strm.readUint8
+  let where = vocab_strm.readInt32
+  let length = vocab_strm.readInt32
+  vocab[term] = (where div 8, length div 8)
+
+vocab_strm.close()
+
+let query = readLine(stdin).strip
+let (where, length) = vocab[query]
+for i, (docid, tf) in postings[where..where+length-1]:
+  echo(fmt"0 Q0 {doc_ids[docid]} {i+1} {tf} JASSjr")

--- a/JASSjr_search.nim
+++ b/JASSjr_search.nim
@@ -11,13 +11,13 @@ import std/tables
 const k1 = 0.9 # BM25 k1 parameter
 const b = 0.4 # BM25 b parameter
 
-let doc_ids = readFile("docids.bin").strip.splitLines
+let doc_ids = readFile("docids.bin").strip().splitLines()
 
 var doc_lengths: seq[int32]
 let doc_lengths_strm = newFileStream("lengths.bin", fmRead)
 
-while not doc_lengths_strm.atEnd:
-  let length = doc_lengths_strm.readInt32
+while not doc_lengths_strm.atEnd():
+  let length = doc_lengths_strm.readInt32()
   doc_lengths.add(length)
 
 doc_lengths_strm.close()
@@ -27,12 +27,12 @@ var postings: seq[tuple[docid: int32, tf: int32]]
 var vocab = initTable[string, tuple[where: int32, length: int32]]()
 let vocab_strm = newFileStream("vocab.bin", fmRead)
 
-while not vocab_strm.atEnd:
-  let term_length = vocab_strm.readUint8
+while not vocab_strm.atEnd():
+  let term_length = vocab_strm.readUint8()
   let term = vocab_strm.readStr(int(term_length))
-  discard vocab_strm.readUint8
-  let where = vocab_strm.readInt32
-  let length = vocab_strm.readInt32
+  discard vocab_strm.readUint8()
+  let where = vocab_strm.readInt32()
+  let length = vocab_strm.readInt32()
   vocab[term] = (where, length div 8)
 
 vocab_strm.close()
@@ -41,7 +41,7 @@ try:
   while true:
     let query = readLine(stdin)
 
-    let terms = query.splitWhitespace
+    let terms = query.splitWhitespace()
 
     for term in terms:
       try:
@@ -54,8 +54,8 @@ try:
         let postings_strm = newFileStream(postings_fh)
 
         for i in 0 .. length:
-          let docid = postings_strm.readInt32
-          let tf = postings_strm.readInt32
+          let docid = postings_strm.readInt32()
+          let tf = postings_strm.readInt32()
           postings.add((docid, tf))
 
         postings_strm.close() # strm owns fh

--- a/JASSjr_search.nim
+++ b/JASSjr_search.nim
@@ -8,8 +8,8 @@ import std/strformat
 import std/strutils
 import std/tables
 
-let k1 = 0.9 # BM25 k1 parameter
-let b = 0.4 # BM25 b parameter
+const k1 = 0.9 # BM25 k1 parameter
+const b = 0.4 # BM25 b parameter
 
 let doc_ids = readFile("docids.bin").strip.splitLines
 

--- a/JASSjr_search.nim
+++ b/JASSjr_search.nim
@@ -48,11 +48,19 @@ for i, _ in accumulators:
 
 try:
   while true:
+    var query_id = 0
+
     let query = readLine(stdin)
 
-    let terms = query.splitWhitespace()
+    var terms = query.splitWhitespace()
     if len(terms) == 0:
       continue
+
+    try:
+      query_id = parseInt(terms[0])
+      terms.delete(0)
+    except ValueError:
+      discard
 
     for i, _ in accumulators:
       accumulators[i][0] = 0
@@ -88,6 +96,6 @@ try:
     for i, (rsv, docid) in accumulators:
       if rsv == 0 or i == 10:
         break
-      echo(fmt"0 Q0 {doc_ids[docid]} {i+1} {rsv:.4f} JASSjr")
+      echo(fmt"{query_id} Q0 {doc_ids[docid]} {i+1} {rsv:.4f} JASSjr")
 except EOFError:
   discard

--- a/JASSjr_search.nim
+++ b/JASSjr_search.nim
@@ -3,6 +3,9 @@
 # Copyright (c) 2024 Vaughan Kitchen
 # Minimalistic BM25 search engine.
 
+import std/algorithm
+import std/math
+import std/sequtils
 import std/streams
 import std/strformat
 import std/strutils
@@ -22,6 +25,8 @@ while not doc_lengths_strm.atEnd():
 
 doc_lengths_strm.close()
 
+let average_length = doc_lengths.foldl(a + b) / len(doc_lengths)
+
 var postings: seq[tuple[docid: int32, tf: int32]]
 
 var vocab = initTable[string, tuple[where: int32, length: int32]]()
@@ -37,11 +42,20 @@ while not vocab_strm.atEnd():
 
 vocab_strm.close()
 
+var accumulators = newSeq[(float, int)](len(doc_ids))
+for i, _ in accumulators:
+  accumulators[i][1] = i
+
 try:
   while true:
     let query = readLine(stdin)
 
     let terms = query.splitWhitespace()
+    if len(terms) == 0:
+      continue
+
+    for i, _ in accumulators:
+      accumulators[i][0] = 0
 
     for term in terms:
       try:
@@ -51,6 +65,7 @@ try:
 
         let postings_fh = open("postings.bin")
         postings_fh.setFilePos(where)
+
         let postings_strm = newFileStream(postings_fh)
 
         for i in 0 .. length:
@@ -59,11 +74,20 @@ try:
           postings.add((docid, tf))
 
         postings_strm.close() # strm owns fh
-        for i, (docid, tf) in postings:
-          if i == 10:
-            break
-          echo(fmt"0 Q0 {doc_ids[docid]} {i+1} {tf} JASSjr")
+
+        let idf = ln(len(doc_lengths) / len(postings))
+
+        for (docid, tf) in postings:
+          let rsv = idf * float(tf) * (k1 + 1) / (float(tf) + k1 * (1 - b + b * (float(doc_lengths[docid]) / average_length)))
+          accumulators[docid][0] += rsv
       except KeyError:
         discard
+
+    accumulators.sort(Descending)
+
+    for i, (rsv, docid) in accumulators:
+      if rsv == 0 or i == 10:
+        break
+      echo(fmt"0 Q0 {doc_ids[docid]} {i+1} {rsv} JASSjr")
 except EOFError:
   discard

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ So JASSjr is not as fast as JASSv2, and not quite as good at ranking as JASSv2, 
 | JASSjr_search.go | Go source code to search engine |
 | JASSjr_index.raku | Raku source code to indexer |
 | JASSjr_search.raku | Raku source code to search engine |
+| JASSjr_index.nim | Nim source code to indexer |
+| JASSjr_search.nim | Nim source code to search engine |
 | GNUmakefile | GNU make makefile for macOS / Linux |
 | makefile | NMAKE makefile for Windows |
 | test_documents.xml | Example of how documents should be layed out for indexing | 


### PR DESCRIPTION
Adds a Nim implementation of JASSjr to go alongside the others. Nim is a high level systems programming language with a syntax inspired by Python

This is a direct copy of the Python version with minor changes due to language differences

I have verified the output is the same through the following comparisons:
* docids.bin is the exact same
* lengths.bin is the exact same
* vocab.bin is the same size (it is stored in a different order)
* postings.bin is the same size (it is stored in a different order)
* execute an example query and compare the output is the exact same

Here are some example timings for the various versions on my machine:
| | Time to index (s) | Time for one query (s) | Time for 50 queries (s) |
| - | - | - | - |
| C++ | 15 | 0.28 | 0.68 |
| Java | 18 | 0.33 | 1.10 |
| Python | 74 | 0.85 | 2.80 |
| JavaScript | 35 |  0.75 | 3.80 |
| Elixir | 125 | 0.85 | 2.20 |
| Ruby | 160 | 2.30 | 62.5 |
| Perl | 115 | 0.90 | 3.60 |
| Go | 18 | 0.25 | 0.67 |
| Raku | 140mins | 8 | 170 |
| Nim | 19 | 0.95 | 1.70 |