### PR TITLE
Fix C++ formatting

### DIFF
--- a/JASSjr_index.cpp
+++ b/JASSjr_index.cpp
@@ -17,12 +17,12 @@
 #include <unordered_map>
 
 typedef std::vector<std::pair<int32_t, int32_t>> postings_list;	// a postings list is an ordered pair of <docid,tf> integers
-char buffer[1024 * 1024];					// index line at a time where a line fits in this buffer
-char *current;							// where the lexical analyser is in buffer[]
-char next_token[1024 * 1024];					// the token we're currently building
-std::unordered_map<std::string, postings_list> vocab;		// the in-memory index
-std::vector<std::string>doc_ids;				// the primary keys
-std::vector<int32_t> length_vector;				// hold the length of each document
+char buffer[1024 * 1024];										// index line at a time where a line fits in this buffer
+char *current;													// where the lexical analyser is in buffer[]
+char next_token[1024 * 1024];									// the token we're currently building
+std::unordered_map<std::string, postings_list> vocab;			// the in-memory index
+std::vector<std::string>doc_ids;								// the primary keys
+std::vector<int32_t> length_vector;								// hold the length of each document
 
 /*
 	LEX_GET_NEXT()
@@ -160,7 +160,7 @@ int main(int argc, const char *argv[])
 			if (list.size() == 0 || list[list.size() - 1].first != docid)
 				list.push_back(std::pair<int32_t, int32_t>(docid, 1));	// if the docno for this occurence hasn't changed the increase tf
 			else
-				list[list.size() - 1].second++;				// else create a new <d,tf> pair.
+				list[list.size() - 1].second++;							// else create a new <d,tf> pair.
 
 			/*
 				Compute the document length

--- a/JASSjr_index.cpp
+++ b/JASSjr_index.cpp
@@ -17,12 +17,12 @@
 #include <unordered_map>
 
 typedef std::vector<std::pair<int32_t, int32_t>> postings_list;	// a postings list is an ordered pair of <docid,tf> integers
-char buffer[1024 * 1024];														// index line at a time where a line fits in this buffer
-char *current;																		// where the lexical analyser is in buffer[]
-char next_token[1024 * 1024];													// the token we're currently building
-std::unordered_map<std::string, postings_list> vocab;					// the in-memory index
-std::vector<std::string>doc_ids;												// the primary keys
-std::vector<int32_t> length_vector;											// hold the length of each document
+char buffer[1024 * 1024];					// index line at a time where a line fits in this buffer
+char *current;							// where the lexical analyser is in buffer[]
+char next_token[1024 * 1024];					// the token we're currently building
+std::unordered_map<std::string, postings_list> vocab;		// the in-memory index
+std::vector<std::string>doc_ids;				// the primary keys
+std::vector<int32_t> length_vector;				// hold the length of each document
 
 /*
 	LEX_GET_NEXT()
@@ -30,37 +30,37 @@ std::vector<int32_t> length_vector;											// hold the length of each documen
 	One-character lookahead lexical analyser
 */
 char *lex_get_next()
-{
-/*
-	Skip over whitespace and punctuation (but not XML tags)
-*/
-while (*current != '\0' && !isalnum(*current) && *current != '<')
-	current++;
-
-/*
-	A token is either an XML tag '<'..'>' or a sequence of alpha-numerics.
-*/
-char *start = current;
-if (isalnum(*current))
-	while (isalnum(*current) || *current == '-')				// TREC <DOCNO> primary keys have a hyphen in them
+	{
+	/*
+		Skip over whitespace and punctuation (but not XML tags)
+	*/
+	while (*current != '\0' && !isalnum(*current) && *current != '<')
 		current++;
-else if (*current == '<')
-  {
-    current++;
-	while (*(current - 1) != '>')
+
+	/*
+		A token is either an XML tag '<'..'>' or a sequence of alpha-numerics.
+	*/
+	char *start = current;
+	if (isalnum(*current))
+		while (isalnum(*current) || *current == '-')	// TREC <DOCNO> primary keys have a hyphen in them
+			current++;
+	else if (*current == '<')
+		{
 		current++;
-  }
-else
-	return NULL;			// must be at end of line
+		while (*(current - 1) != '>')
+			current++;
+		}
+	else
+		return NULL;	// must be at end of line
 
-/*
-	Copy and return the token
-*/
-memcpy(next_token, start, current - start);
-next_token[current - start] = '\0';
+	/*
+		Copy and return the token
+	*/
+	memcpy(next_token, start, current - start);
+	next_token[current - start] = '\0';
 
-return next_token;
-}
+	return next_token;
+	}
 
 /*
 	LEX_GET_FIRST()
@@ -68,11 +68,11 @@ return next_token;
 	Start the lexical analysis process
 */
 char *lex_get_first(char *with)
-{
-current = with;
+	{
+	current = with;
 
-return lex_get_next();
-}
+	return lex_get_next();
+	}
 
 /*
 	MAIN()
@@ -80,156 +80,156 @@ return lex_get_next();
 	Simple indexer for TREC WSJ collection
 */
 int main(int argc, const char *argv[])
-{
-int32_t docid = -1;
-int32_t document_length = 0;
-FILE *fp;
-
-/*
-	Make sure we have one paramter, the filename
-*/
-if (argc != 2)
-	exit(printf("Usage:%s <infile.xml>\n", argv[0]));
-
-/*
-	open the file to index
-*/
-if ((fp = fopen(argv[1], "rb")) == NULL)
-	exit(printf("can't open file %s\n", argv[1]));
-
-bool push_next = false;		// is the next token the primary key?
-while (fgets(buffer, sizeof(buffer), fp) != NULL)
 	{
-	for (char *token = lex_get_first(buffer); token != NULL; token = lex_get_next())
+	int32_t docid = -1;
+	int32_t document_length = 0;
+	FILE *fp;
+
+	/*
+		Make sure we have one paramter, the filename
+	*/
+	if (argc != 2)
+		exit(printf("Usage:%s <infile.xml>\n", argv[0]));
+
+	/*
+		open the file to index
+	*/
+	if ((fp = fopen(argv[1], "rb")) == NULL)
+		exit(printf("can't open file %s\n", argv[1]));
+
+	bool push_next = false;		// is the next token the primary key?
+	while (fgets(buffer, sizeof(buffer), fp) != NULL)
+		{
+		for (char *token = lex_get_first(buffer); token != NULL; token = lex_get_next())
+			{
+			/*
+				If we see a <DOC> tag then we're at the start of the next document
+			*/
+			if (strcmp(token, "<DOC>") == 0)
+				{
+				/*
+					Save the previous document length
+				*/
+				if (docid != -1)
+					length_vector.push_back(document_length);
+
+				/*
+					Move on to the next document
+				*/
+				docid++;
+				document_length = 0;
+
+				if ((docid % 1000) == 0)
+					std::cout << docid << " documents indexed\n";
+				}
+
+			/*
+				if the last token we saw was a <DOCNO> then the next token is the primary key
+			*/
+			if (push_next)
+				{
+				doc_ids.push_back(std::string(token));
+				push_next = false;
+				}
+			if (strcmp(token, "<DOCNO>") == 0)
+				push_next = true;
+
+			/*
+				Don't index XML tags
+			*/
+			if (*token == '<')
+				continue;
+
+			/*
+				lower case the string
+			*/
+			std::string lowercase(token);
+			for (auto &ch : lowercase)
+				ch = tolower(ch);
+
+			/*
+				truncate any long tokens at 255 charactes (so that the length can be stored first and in a single byte)
+			*/
+			if (lowercase.size() >= 0xFF)
+				lowercase[0xFF] = '\0';
+
+			/*
+				add the posting to the in-memory index
+			*/
+			postings_list &list = vocab[lowercase];
+			if (list.size() == 0 || list[list.size() - 1].first != docid)
+				list.push_back(std::pair<int32_t, int32_t>(docid, 1));	// if the docno for this occurence hasn't changed the increase tf
+			else
+				list[list.size() - 1].second++;				// else create a new <d,tf> pair.
+
+			/*
+				Compute the document length
+			*/
+			document_length++;
+			}
+		}
+
+	/*
+		If we didn't index any documents then we're done.
+	*/
+	if (docid == -1)
+		return 0;
+
+	/*
+		tell the user we've got to the end of parsing
+	*/
+	std::cout << "Indexed " << docid + 1 << " documents. Serialising...\n";
+
+	/*
+		Save the final document length
+	*/
+	length_vector.push_back(document_length);
+
+	/*
+		store the primary keys
+	*/
+	FILE *docid_fp = fopen("docids.bin", "w+b");
+	for (const auto &id : doc_ids)
+		fprintf(docid_fp, "%s\n", id.c_str());
+
+	FILE *postings_fp = fopen("postings.bin", "w+b");
+	FILE *vocab_fp = fopen("vocab.bin", "w+b");
+
+	/*
+		serialise the in-memory index to disk
+	*/
+	for (const auto &term : vocab)
 		{
 		/*
-			If we see a <DOC> tag then we're at the start of the next document
+			write the postings list to one file
 		*/
-		if (strcmp(token, "<DOC>") == 0)
-			{
-			/*
-				Save the previous document length
-			*/
-			if (docid != -1)
-				length_vector.push_back(document_length);
-
-			/*
-				Move on to the next document
-			*/
-			docid++;
-			document_length = 0;
-
-			if ((docid % 1000) == 0)
-				std::cout << docid << " documents indexed\n";
-			}
+		int32_t where = ftell(postings_fp);
+		int32_t size = sizeof(term.second[0]) * term.second.size();
+		fwrite(&term.second[0], 1, size, postings_fp);
 
 		/*
-			if the last token we saw was a <DOCNO> then the next token is the primary key
+			write the vocabulary to a second file (one byte length, string, '\0', 4 byte where, 4 byte size)
 		*/
-		if (push_next)
-			{
-			doc_ids.push_back(std::string(token));
-			push_next = false;
-			}
-		if (strcmp(token, "<DOCNO>") == 0)
-			push_next = true;
-
-		/*
-			Don't index XML tags
-		*/
-		if (*token == '<')
-			continue;
-
-		/*
-			lower case the string
-		*/
-		std::string lowercase(token);
-		for (auto &ch : lowercase)
-			ch = tolower(ch);
-
-		/*
-			truncate any long tokens at 255 charactes (so that the length can be stored first and in a single byte)
-		*/
-		if (lowercase.size() >= 0xFF)
-			lowercase[0xFF] = '\0';
-
-		/*
-			add the posting to the in-memory index
-		*/
-		postings_list &list = vocab[lowercase];
-		if (list.size() == 0 || list[list.size() - 1].first != docid)
-			list.push_back(std::pair<int32_t, int32_t>(docid, 1));							// if the docno for this occurence hasn't changed the increase tf
-		else
-			list[list.size() - 1].second++;												// else create a new <d,tf> pair.
-
-		/*
-			Compute the document length
-		*/
-		document_length++;
+		char token_length = term.first.size();
+		fwrite(&token_length, sizeof(token_length), 1, vocab_fp);
+		fwrite(term.first.c_str(), 1, token_length + 1, vocab_fp);
+		fwrite(&where, sizeof(where), 1, vocab_fp);
+		fwrite(&size, sizeof(size), 1, vocab_fp);
 		}
-	}
 
-/*
-	If we didn't index any documents then we're done.
-*/
-if (docid == -1)
+	/*
+		store the document lengths
+	*/
+	FILE *lengths_fp = fopen("lengths.bin", "w+b");
+	fwrite(&length_vector[0], sizeof(length_vector[0]), length_vector.size(), lengths_fp);
+
+	/*
+		clean up
+	*/
+	fclose(docid_fp);
+	fclose(postings_fp);
+	fclose(vocab_fp);
+	fclose(lengths_fp);
+
 	return 0;
-
-/*
-	tell the user we've got to the end of parsing
-*/
-std::cout << "Indexed " << docid + 1 << " documents. Serialising...\n";
-
-/*
-	Save the final document length
-*/
-length_vector.push_back(document_length);
-
-/*
-	store the primary keys
-*/
-FILE *docid_fp = fopen("docids.bin", "w+b");
-for (const auto &id : doc_ids)
-	fprintf(docid_fp, "%s\n", id.c_str());
-
-FILE *postings_fp = fopen("postings.bin", "w+b");
-FILE *vocab_fp = fopen("vocab.bin", "w+b");
-
-/*
-	serialise the in-memory index to disk
-*/
-for (const auto &term : vocab)
-	{
-	/*
-		write the postings list to one file
-	*/
-	int32_t where = ftell(postings_fp);
-	int32_t size = sizeof(term.second[0]) * term.second.size();
-	fwrite(&term.second[0], 1, size, postings_fp);
-
-	/*
-		write the vocabulary to a second file (one byte length, string, '\0', 4 byte where, 4 byte size)
-	*/
-	char token_length = term.first.size();
-	fwrite(&token_length, sizeof(token_length), 1, vocab_fp);
-	fwrite(term.first.c_str(), 1, token_length + 1, vocab_fp);
-	fwrite(&where, sizeof(where), 1, vocab_fp);
-	fwrite(&size, sizeof(size), 1, vocab_fp);
 	}
-
-/*
-	store the document lengths
-*/
-FILE *lengths_fp = fopen("lengths.bin", "w+b");
-fwrite(&length_vector[0], sizeof(length_vector[0]), length_vector.size(), lengths_fp);
-
-/*
-	clean up
-*/
-fclose(docid_fp);
-fclose(postings_fp);
-fclose(vocab_fp);
-fclose(lengths_fp);
-
-return 0;
-}

--- a/JASSjr_search.cpp
+++ b/JASSjr_search.cpp
@@ -119,12 +119,12 @@ int main(int argc, const char *argv[])
 	/*
 		Read the primary_keys
 	*/
-	char buffer[1024];					// the user's query (and also used to load the vocab)
-	std::vector<std::string>primary_key;			// the list of global IDs (i.e. primary keys)
+	char buffer[1024];						// the user's query (and also used to load the vocab)
+	std::vector<std::string>primary_key;	// the list of global IDs (i.e. primary keys)
 	FILE *fp = fopen("docids.bin", "rb");
 	while (fgets(buffer, sizeof(buffer), fp) != NULL)
 		{
-		buffer[strlen(buffer) - 1] = '\0';		// strip the '\n' that fgets leaves on the end
+		buffer[strlen(buffer) - 1] = '\0';	// strip the '\n' that fgets leaves on the end
 		primary_key.push_back(std::string(buffer));
 		}
 
@@ -141,7 +141,7 @@ int main(int argc, const char *argv[])
 	while (current < vocab + file_size)
 		{
 		string_length = *current;
-		where = *((int32_t *)(current + string_length + 2));			// +1 for the length and + 1 for the '\0'
+		where = *((int32_t *)(current + string_length + 2));					// +1 for the length and + 1 for the '\0'
 		size = *((int32_t *)(current + string_length + 2 + sizeof(int32_t)));	// +1 for the length and + 1 for the '\0'
 
 		dictionary[std::string(current + 1)] = vocab_entry(where, size);
@@ -152,7 +152,7 @@ int main(int argc, const char *argv[])
 		Allocate buffers
 	*/
 	int32_t *postings_buffer= new int32_t[(max_docs + 1) * 2];	// the postings list once loaded from disk
-	double *rsv = new double[max_docs];				// array of rsv values
+	double *rsv = new double[max_docs];							// array of rsv values
 
 	/*
 		Set up the rsv pointers

--- a/JASSjr_search.cpp
+++ b/JASSjr_search.cpp
@@ -24,8 +24,8 @@
 	CONSTANTS
 	---------
 */
-static constexpr double k1 = 0.9;				// BM25 k1 parameter
-static constexpr double b = 0.4;					// BM25 b parameter
+static constexpr double k1 = 0.9;	// BM25 k1 parameter
+static constexpr double b = 0.4;	// BM25 b parameter
 
 /*
 	CLASS VOCAB_ENTRY
@@ -34,7 +34,7 @@ static constexpr double b = 0.4;					// BM25 b parameter
 class vocab_entry
 	{
 	public:
-		int32_t where, size;		// where on the disk and how large (in bytes) is the postings list?
+		int32_t where, size;	// where on the disk and how large (in bytes) is the postings list?
 
 		vocab_entry() : where(0), size(0) {}
 		vocab_entry(int32_t where, int32_t size): where(where), size(size) {}
@@ -46,24 +46,24 @@ class vocab_entry
 	Read the entire contents of the given file into memory and return its size.
 */
 char *read_entire_file(const char *filename, size_t &file_size)
-{
-char *block = NULL;
-FILE *fp;
-struct stat details;
+	{
+	char *block = NULL;
+	FILE *fp;
+	struct stat details;
 
-file_size = 0;
-if ((fp = fopen(filename, "rb")) == NULL)
-	return NULL;
+	file_size = 0;
+	if ((fp = fopen(filename, "rb")) == NULL)
+		return NULL;
 
-if (fstat(fileno(fp), &details) == 0)
-	if ((block = (char *)malloc(details.st_size)) != NULL)
-		fread(block, 1, details.st_size, fp);
+	if (fstat(fileno(fp), &details) == 0)
+		if ((block = (char *)malloc(details.st_size)) != NULL)
+			fread(block, 1, details.st_size, fp);
 
-file_size = details.st_size;
+	file_size = details.st_size;
 
-fclose(fp);
-return block;
-}
+	fclose(fp);
+	return block;
+	}
 
 /*
 	COMPARE_RSV()
@@ -71,9 +71,9 @@ return block;
 	Callback from std::sort for two rsv values. Tie break on the document id.
 */
 bool compare_rsv(double *first, double *second)
-{
-return *first > *second ? true : *first == *second ? first > second : false;
-}
+	{
+	return *first > *second ? true : *first == *second ? first > second : false;
+	}
 
 /*
 	MAIN()
@@ -81,159 +81,159 @@ return *first > *second ? true : *first == *second ? first > second : false;
 	Simple search engine ranking on BM25.
 */
 int main(int argc, const char *argv[])
-{
-size_t file_size;
-char *vocab = read_entire_file("vocab.bin", file_size);
-char *current;
-int32_t where, size, string_length;
-char seperators[255];
-char *into = seperators;
-int32_t *length_vector;
-
-/*
-	Set up the tokenizer seperator characters
-*/
-for (int32_t ch = 1; ch <= 0xFF; ch++)
-	if (!isalnum(ch) && ch != '<' && ch != '>' && ch != '-')
-		*into++ = ch;
-*into++ = '\0';
-
-/*
-	Read the document lengths
-*/
-size_t length_filesize_in_bytes;
-double average_document_length = 0;
-length_vector = reinterpret_cast<int32_t *>(read_entire_file("lengths.bin", length_filesize_in_bytes));
-if (length_filesize_in_bytes == 0)
-	exit(printf("Could not find an index in the current directory\n"));
-
-/*
-	Compute the average document length for BM25
-*/
-double documents_in_collection = length_filesize_in_bytes / sizeof(int32_t);
-int32_t max_docs = static_cast<int32_t>(documents_in_collection);
-for (int32_t document = 0; document < max_docs; document++)
-	average_document_length += length_vector[document];
-average_document_length /= documents_in_collection;
-
-/*
-	Read the primary_keys
-*/
-char buffer[1024];													// the user's query (and also used to load the vocab)
-std::vector<std::string>primary_key;							// the list of global IDs (i.e. primary keys)
-FILE *fp = fopen("docids.bin", "rb");
-while (fgets(buffer, sizeof(buffer), fp) != NULL)
 	{
-	buffer[strlen(buffer) - 1] = '\0';		// strip the '\n' that fgets leaves on the end
-	primary_key.push_back(std::string(buffer));
-	}
- 
- /*
-	Open the postings list file
-*/
-FILE *postings_file = fopen("postings.bin", "rb");
- 
-/*
-	Build the vocabulary in memory
-*/
-std::unordered_map<std::string, vocab_entry>dictionary;	// the vocab
-current = vocab;
-while (current < vocab + file_size)
-	{
-	string_length = *current;
-	where = *((int32_t *)(current + string_length + 2));			// +1 for the length and + 1 for the '\0'
-	size = *((int32_t *)(current + string_length + 2 + sizeof(int32_t)));			// +1 for the length and + 1 for the '\0'
+	size_t file_size;
+	char *vocab = read_entire_file("vocab.bin", file_size);
+	char *current;
+	int32_t where, size, string_length;
+	char seperators[255];
+	char *into = seperators;
+	int32_t *length_vector;
 
-	dictionary[std::string(current + 1)] = vocab_entry(where, size);
-	current += string_length + 2 + 2 * sizeof(int32_t);
-	}
- 
-/*
-	Allocate buffers
-*/
-int32_t *postings_buffer= new int32_t[(max_docs + 1) * 2];			// the postings list once loaded from disk
-double *rsv = new double[max_docs];											// array of rsv values
-
-/*
-	Set up the rsv pointers
-*/
-double **rsv_pointers = new double *[max_docs];	
-double **rsvp = rsv_pointers;
-for (double *pointer = rsv; pointer < rsv + max_docs; pointer++)
-	*rsvp++ = pointer;
-
-/*
-	Search (one query per line)
-*/
-while (fgets(buffer, sizeof(buffer), stdin) !=  NULL)
-	{
 	/*
-		Zero the accumulator array.
+		Set up the tokenizer seperator characters
 	*/
-	memset(rsv, 0, sizeof(*rsv) * max_docs);
-	bool first_term = true;
-	long query_id = 0;
-	for (char *token = strtok(buffer, seperators); token != NULL; token = strtok(NULL, seperators))
+	for (int32_t ch = 1; ch <= 0xFF; ch++)
+		if (!isalnum(ch) && ch != '<' && ch != '>' && ch != '-')
+			*into++ = ch;
+	*into++ = '\0';
+
+	/*
+		Read the document lengths
+	*/
+	size_t length_filesize_in_bytes;
+	double average_document_length = 0;
+	length_vector = reinterpret_cast<int32_t *>(read_entire_file("lengths.bin", length_filesize_in_bytes));
+	if (length_filesize_in_bytes == 0)
+		exit(printf("Could not find an index in the current directory\n"));
+
+	/*
+		Compute the average document length for BM25
+	*/
+	double documents_in_collection = length_filesize_in_bytes / sizeof(int32_t);
+	int32_t max_docs = static_cast<int32_t>(documents_in_collection);
+	for (int32_t document = 0; document < max_docs; document++)
+		average_document_length += length_vector[document];
+	average_document_length /= documents_in_collection;
+
+	/*
+		Read the primary_keys
+	*/
+	char buffer[1024];					// the user's query (and also used to load the vocab)
+	std::vector<std::string>primary_key;			// the list of global IDs (i.e. primary keys)
+	FILE *fp = fopen("docids.bin", "rb");
+	while (fgets(buffer, sizeof(buffer), fp) != NULL)
 		{
-		/*
-			If the first token is a number then assume a TREC query number, and skip it
-		*/
-		if (first_term && isdigit(*buffer))
-			{
-			query_id = atol(buffer);
-			first_term = false;
-			continue;
-			}
+		buffer[strlen(buffer) - 1] = '\0';		// strip the '\n' that fgets leaves on the end
+		primary_key.push_back(std::string(buffer));
+		}
 
-		first_term = false;
+	 /*
+		Open the postings list file
+	*/
+	FILE *postings_file = fopen("postings.bin", "rb");
 
-		/*
-			Does the term exist in the collection?
-		*/
-		vocab_entry term_details;
-		if ((term_details = dictionary[std::string(token)]).size != 0)
-			{
-			/*
-				Seek and read the postings list
-			*/
-			fseek(postings_file, term_details.where, SEEK_SET);
-			(void)fread(postings_buffer, 1, term_details.size, postings_file);
-			int32_t postings = term_details.size / (sizeof(int32_t) * 2);
-			std::pair<int32_t, int32_t> *list = (std::pair<int32_t, int32_t> *)(&postings_buffer[0]);
-	
-			/*
-				Compute the IDF component of BM25 as log(N/n).
-				if IDF == 0 then don't process this postings list as the BM25 contribution of this term will be zero.
-			*/
-			if (documents_in_collection != postings)
-				{
-				double idf = log(documents_in_collection / postings);
-		
-				/*
-					Process the postings list by simply adding the BM25 component for this document into the accumulators array
-				*/
-				for (int32_t which = 0; which < postings; which++, list++)
-					{
-					int32_t d = list->first;
-					int32_t tf = list->second;
-					rsv[d] += idf * ((tf * (k1 + 1)) / (tf + k1 * (1 - b + b * (length_vector[d] / average_document_length))));
-					}
-				}
-			}
+	/*
+		Build the vocabulary in memory
+	*/
+	std::unordered_map<std::string, vocab_entry>dictionary;	// the vocab
+	current = vocab;
+	while (current < vocab + file_size)
+		{
+		string_length = *current;
+		where = *((int32_t *)(current + string_length + 2));			// +1 for the length and + 1 for the '\0'
+		size = *((int32_t *)(current + string_length + 2 + sizeof(int32_t)));	// +1 for the length and + 1 for the '\0'
+
+		dictionary[std::string(current + 1)] = vocab_entry(where, size);
+		current += string_length + 2 + 2 * sizeof(int32_t);
 		}
 
 	/*
-		Sort the results list
+		Allocate buffers
 	*/
-	std::sort(&rsv_pointers[0], &rsv_pointers[max_docs], compare_rsv);
+	int32_t *postings_buffer= new int32_t[(max_docs + 1) * 2];	// the postings list once loaded from disk
+	double *rsv = new double[max_docs];				// array of rsv values
 
 	/*
-		Print the (at most) top 1000 documents in the results list in TREC eval format which is:
-		query-id Q0 document-id rank score run-name
+		Set up the rsv pointers
 	*/
-	std::cout << std::fixed << std::setprecision(4);
+	double **rsv_pointers = new double *[max_docs];
+	double **rsvp = rsv_pointers;
+	for (double *pointer = rsv; pointer < rsv + max_docs; pointer++)
+		*rsvp++ = pointer;
 
-	for (int32_t position = 0; *rsv_pointers[position] != 0.0 && position < 1000; position++)
-		std::cout << query_id << " Q0 " << primary_key[rsv_pointers[position] - rsv] << " " << position + 1 << " " << std::setw(2) << *rsv_pointers[position] << " JASSjr\n";
+	/*
+		Search (one query per line)
+	*/
+	while (fgets(buffer, sizeof(buffer), stdin) !=  NULL)
+		{
+		/*
+			Zero the accumulator array.
+		*/
+		memset(rsv, 0, sizeof(*rsv) * max_docs);
+		bool first_term = true;
+		long query_id = 0;
+		for (char *token = strtok(buffer, seperators); token != NULL; token = strtok(NULL, seperators))
+			{
+			/*
+				If the first token is a number then assume a TREC query number, and skip it
+			*/
+			if (first_term && isdigit(*buffer))
+				{
+				query_id = atol(buffer);
+				first_term = false;
+				continue;
+				}
+
+			first_term = false;
+
+			/*
+				Does the term exist in the collection?
+			*/
+			vocab_entry term_details;
+			if ((term_details = dictionary[std::string(token)]).size != 0)
+				{
+				/*
+					Seek and read the postings list
+				*/
+				fseek(postings_file, term_details.where, SEEK_SET);
+				(void)fread(postings_buffer, 1, term_details.size, postings_file);
+				int32_t postings = term_details.size / (sizeof(int32_t) * 2);
+				std::pair<int32_t, int32_t> *list = (std::pair<int32_t, int32_t> *)(&postings_buffer[0]);
+
+				/*
+					Compute the IDF component of BM25 as log(N/n).
+					if IDF == 0 then don't process this postings list as the BM25 contribution of this term will be zero.
+				*/
+				if (documents_in_collection != postings)
+					{
+					double idf = log(documents_in_collection / postings);
+
+					/*
+						Process the postings list by simply adding the BM25 component for this document into the accumulators array
+					*/
+					for (int32_t which = 0; which < postings; which++, list++)
+						{
+						int32_t d = list->first;
+						int32_t tf = list->second;
+						rsv[d] += idf * ((tf * (k1 + 1)) / (tf + k1 * (1 - b + b * (length_vector[d] / average_document_length))));
+						}
+					}
+				}
+			}
+
+		/*
+			Sort the results list
+		*/
+		std::sort(&rsv_pointers[0], &rsv_pointers[max_docs], compare_rsv);
+
+		/*
+			Print the (at most) top 1000 documents in the results list in TREC eval format which is:
+			query-id Q0 document-id rank score run-name
+		*/
+		std::cout << std::fixed << std::setprecision(4);
+
+		for (int32_t position = 0; *rsv_pointers[position] != 0.0 && position < 1000; position++)
+			std::cout << query_id << " Q0 " << primary_key[rsv_pointers[position] - rsv] << " " << position + 1 << " " << std::setw(2) << *rsv_pointers[position] << " JASSjr\n";
+		}
 	}
-}


### PR DESCRIPTION
The C++ code lacks indentation making it difficult to read. This indents each function body fixing that. I have used a four character width tab as this seems to be the modern default. I am happy to convert to an eight character tab or the use of spaces if that is your preference. I can also convert to tabs at start of line, and spaces for line ending comment indentation which would make it tab width agnostic

Github tab width preferences can be configured at https://github.com/settings/appearance as per the instructions at https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-user-account-settings/managing-your-tab-size-rendering-preference