### PR TITLE
Add license file

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,24 @@
+BSD 2-Clause License
+
+Copyright (c) 2019, 2023, 2024 Andrew Trotman, Kat Lilly, Vaughan Kitchen
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ So JASSjr is not as fast as JASSv2, and not quite as good at ranking as JASSv2, 
 | Filename | Purpose |
 |------------|-----------|
 | README.md | This file |
+| LICENSE.txt | A copy of the 2-clause BSD license |
 | JASSjr_index.cpp | C/C++ source code to indexer |
 | JASSjr_search.cpp | C/C++ source code to search engine |
 | JASSjr_index.java | Java source code to indexer |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # JASSjr #
 JASSjr, the minimalistic BM25 search engine for indexing and searching the TREC WSJ collection.
 
-Copyright (c) 2019 Andrew Trotman and Kat Lilly \
-Copyright (c) 2023, 2024 Vaughan Kitchen \
+Copyright (c) 2019, 2023, 2024 Andrew Trotman, Kat Lilly, Vaughan Kitchen \
 Released under the 2-clause BSD licence.
 
 Please fork our repo.  Please report any bugs.
@@ -159,5 +158,3 @@ So JASSjr is not as fast as JASSv2, and not quite as good at ranking as JASSv2, 
 | test_documents.xml | Example of how documents should be layed out for indexing | 
 | 51-100.titles.txt | TREC topics 51-100 titles as queries |
 | 51-100.qrels.txt | TREC topics 51-100 human judgments |
-
-Copyright (c) 2019 Andrew Trotman and Kat Lilly


### PR DESCRIPTION
Having the license file causes Github to display the license terms in the about sidebar of the project. This is simply a convenience feature

The license text is taken from https://opensource.org/license/bsd-2-clause

And the copyright is updated to suggest that the continued project development is not a fork in advice from https://law.stackexchange.com/questions/16847/how-should-multiple-copyright-holders-be-credited-using-the-mit-license