### PR TITLE
JASSjr in Zig

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,12 @@
-all : JASSjr_index JASSjr_search JASSjr_index.class JASSjr_search.class
+default : cpp java
+
+all : cpp java zig
+
+cpp : JASSjr_index JASSjr_search
+
+java : JASSjr_index.class JASSjr_search.class
+
+zig : JASSjr_index_zig JASSjr_search_zig
 
 JASSjr_index : JASSjr_index.cpp
 	g++ -std=c++11 -O3 -Wno-unused-result JASSjr_index.cpp -o JASSjr_index
@@ -12,8 +20,16 @@ JASSjr_index.class : JASSjr_index.java
 JASSjr_search.class : JASSjr_search.java
 	javac JASSjr_search.java
 
+JASSjr_index_zig : JASSjr_index.zig
+	zig build-exe --name JASSjr_index_zig JASSjr_index.zig
+
+JASSjr_search_zig : JASSjr_search.zig
+	zig build-exe --name JASSjr_search_zig JASSjr_search.zig
+
 clean:
-	- rm JASSjr_search JASSjr_index 'JASSjr_index.class' 'JASSjr_search.class' 'JASSjr_index$$Posting.class' 'JASSjr_index$$PostingsList.class' 'JASSjr_search$$CompareRsv.class' 'JASSjr_search$$VocabEntry.class'
+	- rm JASSjr_index JASSjr_search
+	- rm 'JASSjr_index.class' 'JASSjr_search.class' 'JASSjr_index$$Posting.class' 'JASSjr_index$$PostingsList.class' 'JASSjr_search$$CompareRsv.class' 'JASSjr_search$$VocabEntry.class'
+	- rm JASSjr_index_zig JASSjr_search_zig
 
 clean_index:
 	- rm docids.bin lengths.bin postings.bin vocab.bin

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -21,10 +21,10 @@ JASSjr_search.class : JASSjr_search.java
 	javac JASSjr_search.java
 
 JASSjr_index_zig : JASSjr_index.zig
-	zig build-exe --name JASSjr_index_zig JASSjr_index.zig
+	zig build-exe -O ReleaseFast --name JASSjr_index_zig JASSjr_index.zig
 
 JASSjr_search_zig : JASSjr_search.zig
-	zig build-exe --name JASSjr_search_zig JASSjr_search.zig
+	zig build-exe -O ReleaseFast --name JASSjr_search_zig JASSjr_search.zig
 
 clean:
 	- rm JASSjr_index JASSjr_search

--- a/JASSjr_index.zig
+++ b/JASSjr_index.zig
@@ -41,11 +41,13 @@ const Lexer = struct {
     }
 };
 
+// Simple indexer for TREC WSJ collection
 pub fn main() !void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
 
     const argv = try std.process.argsAlloc(arena.allocator());
 
+    // Make sure we have one parameter, the filename
     if (argv.len != 2) {
         std.debug.print("Usage: {s} <infile.xml>\n", .{argv[0]});
         std.process.exit(0);

--- a/JASSjr_index.zig
+++ b/JASSjr_index.zig
@@ -44,12 +44,13 @@ const Lexer = struct {
 // Simple indexer for TREC WSJ collection
 pub fn main() !void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    const stdout = std.io.getStdOut().writer();
 
     const argv = try std.process.argsAlloc(arena.allocator());
 
     // Make sure we have one parameter, the filename
     if (argv.len != 2) {
-        std.debug.print("Usage: {s} <infile.xml>\n", .{argv[0]});
+        try stdout.print("Usage: {s} <infile.xml>\n", .{argv[0]});
         std.process.exit(0);
     }
 
@@ -76,7 +77,7 @@ pub fn main() !void {
                 doc_id += 1;
                 document_length = 0;
                 if (@rem(doc_id, 1000) == 0)
-                    std.debug.print("{d} documents indexed\n", .{doc_id});
+                    try stdout.print("{d} documents indexed\n", .{doc_id});
             }
             // If the last token we saw was a <DOCNO> then the next token is the primary key
             if (push_next) {
@@ -124,7 +125,7 @@ pub fn main() !void {
     try lengths_vector.append(document_length);
 
     // Tell the user we've got to the end of parsing
-    std.debug.print("Indexed {d} documents. Serialing...\n", .{doc_id + 1});
+    try stdout.print("Indexed {d} documents. Serialing...\n", .{doc_id + 1});
 
     // Store the primary keys
     const docids_fh = try std.fs.cwd().createFile("docids.bin", .{});

--- a/JASSjr_index.zig
+++ b/JASSjr_index.zig
@@ -1,0 +1,127 @@
+// Copyright (c) 2024 Vaughan Kitchen
+// Minimalistic BM25 search engine.
+
+const std = @import("std");
+const native_endian = @import("builtin").target.cpu.arch.endian();
+
+// Pair definition for a value in a postings list
+const Posting = struct { i32, i32 };
+
+// One-character lookahead lexical analyser
+const Lexer = struct {
+    buffer: []u8,
+    current: usize,
+
+    fn init(buffer: []u8) Lexer {
+        return Lexer{ .buffer = buffer, .current = 0 };
+    }
+
+    // Conform to Zig naming conventions for iterators
+    fn next(self: *Lexer) ?[]u8 {
+        // Skip over whitespace and punctuation (but not XML tags)
+        while (self.current < self.buffer.len and !std.ascii.isAlphanumeric(self.buffer[self.current]) and self.buffer[self.current] != '<')
+            self.current += 1;
+
+        // A token is either an XML tag '<'..'>' or a sequence of alpha-numerics.
+        const start = self.current;
+        if (self.current >= self.buffer.len) {
+            return null; // must be at end of line
+        } else if (std.ascii.isAlphanumeric(self.buffer[self.current])) {
+            // TREC <DOCNO> primary keys have a hyphen in them
+            while (self.current < self.buffer.len and (std.ascii.isAlphanumeric(self.buffer[self.current]) or self.buffer[self.current] == '-'))
+                self.current += 1;
+        } else if (self.buffer[self.current] == '<') {
+            self.current += 1;
+            while (self.current < self.buffer.len and self.buffer[self.current - 1] != '>')
+                self.current += 1;
+        }
+
+        // Return the token as a slice. This won't live past the underlying buffer
+        return self.buffer[start..self.current];
+    }
+};
+
+pub fn main() !void {
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+
+    const argv = try std.process.argsAlloc(arena.allocator());
+
+    if (argv.len != 2) {
+        std.debug.print("Usage: {s} <infile.xml>\n", .{argv[0]});
+        std.process.exit(0);
+    }
+
+    var vocab = std.StringHashMap(std.ArrayList(Posting)).init(arena.allocator());
+    var doc_ids = std.ArrayList([]u8).init(arena.allocator());
+    var length_vector = std.ArrayList(i32).init(arena.allocator());
+
+    var doc_id: i32 = -1;
+    var document_length: i32 = 0;
+
+    const fh = try std.fs.cwd().openFile(argv[1], .{});
+    var stream = std.io.bufferedReader(fh.reader());
+
+    var buf: [2048]u8 = undefined;
+    var push_next = false;
+    while (try stream.reader().readUntilDelimiterOrEof(&buf, '\n')) |line| {
+        var lex = Lexer.init(line);
+        while (lex.next()) |token| {
+            if (std.mem.eql(u8, token, "<DOC>")) {
+                // Save the previous document length
+                if (doc_id != -1)
+                    try length_vector.append(document_length);
+                // Move on to the next document
+                doc_id += 1;
+                document_length = 0;
+                if (@rem(doc_id, 1000) == 0)
+                    std.debug.print("{d} documents indexed\n", .{doc_id});
+            }
+            // If the last token we saw was a <DOCNO> then the next token is the primary key
+            if (push_next) {
+                const primary_key = try arena.allocator().dupe(u8, token);
+                try doc_ids.append(primary_key);
+                push_next = false;
+            }
+            if (std.mem.eql(u8, token, "<DOCNO>")) {
+                push_next = true;
+            }
+            // Don't index XML tags
+            if (token[0] == '<')
+                continue;
+
+            // Lower case the string
+            _ = std.ascii.lowerString(token, token);
+
+            // Truncate any long tokens at 255 charactes (so that the length can be stored first and in a single byte)
+
+            // Add the posting to the in-memory index
+            const gop = try vocab.getOrPut(token);
+            if (!gop.found_existing) {
+                // If the term isn't in the vocab yet
+                const term = try arena.allocator().dupe(u8, token);
+                gop.key_ptr.* = term;
+                gop.value_ptr.* = std.ArrayList(Posting).init(arena.allocator());
+                try gop.value_ptr.append(.{ doc_id, 1 });
+            } else {
+                if (gop.value_ptr.getLast()[0] == doc_id) {
+                    // If the docno for this occurence hasn't changed the increase tf
+                    gop.value_ptr.items[gop.value_ptr.items.len - 1][1] += 1;
+                } else {
+                    // Else create a new <d,tf> pair.
+                    try gop.value_ptr.append(.{ doc_id, 1 });
+                }
+            }
+
+            // Compute the document length
+            document_length += 1;
+        }
+    }
+
+    var it = vocab.iterator();
+    while (it.next()) |kv| {
+        std.debug.print("{s}\n", .{kv.key_ptr.*});
+        for (kv.value_ptr.items) |pair| {
+            std.debug.print("  {d} {d}\n", pair);
+        }
+    }
+}

--- a/JASSjr_search.zig
+++ b/JASSjr_search.zig
@@ -123,7 +123,7 @@ pub fn main() !void {
         // Print the (at most) top 1000 documents in the results list in TREC eval format which is:
         // query-id Q0 document-id rank score run-name
         for (rsv_pointers, 0..) |r, i| {
-            if (rsv[r] == 0 or r == 1000) break;
+            if (rsv[r] == 0 or i == 1000) break;
             if (r > 0) std.debug.print("{d} Q0 {s} {d} {d:.4} JASSjr\n", .{ query_id, primary_keys[r], i + 1, rsv[r] });
         }
     }

--- a/JASSjr_search.zig
+++ b/JASSjr_search.zig
@@ -28,7 +28,9 @@ const StringContext = struct {
 // Simple search engine ranking on BM25.
 pub fn main() !void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    const stdout = std.io.getStdOut().writer();
+    const stdout_raw = std.io.getStdOut().writer();
+    var stdout_stream = std.io.bufferedWriter(stdout_raw);
+    const stdout = stdout_stream.writer();
 
     // Read the document lengths
     var fh = try std.fs.cwd().openFile("lengths.bin", .{});
@@ -86,7 +88,7 @@ pub fn main() !void {
 
     // Open the postings list file
     const postings = try arena.allocator().alloc(struct { u32, u32 }, documents_in_collection * 2);
-    var postings_fh = try std.fs.cwd().openFile("postings.bin", .{});
+    const postings_fh = try std.fs.cwd().openFile("postings.bin", .{});
     defer postings_fh.close();
 
     // Allocate buffers
@@ -143,5 +145,6 @@ pub fn main() !void {
             if (rsv[r] == 0 or i == 1000) break;
             try stdout.print("{d} Q0 {s} {d} {d:.4} JASSjr\n", .{ query_id, primary_keys[r], i + 1, rsv[r] });
         }
+        try stdout_stream.flush();
     }
 }

--- a/JASSjr_search.zig
+++ b/JASSjr_search.zig
@@ -4,6 +4,9 @@
 const std = @import("std");
 const native_endian = @import("builtin").target.cpu.arch.endian();
 
+const k1 = 0.9; // BM25 k1 parameter
+const b = 0.4; // BM25 b parameter
+
 pub fn main() !void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
 
@@ -11,7 +14,8 @@ pub fn main() !void {
     var fh = try std.fs.cwd().openFile("lengths.bin", .{});
 
     const lengths_stat = try fh.stat();
-    const lengths_vector = try arena.allocator().alloc(i32, lengths_stat.size / 4);
+    const documents_in_collection = lengths_stat.size / 4;
+    const lengths_vector = try arena.allocator().alloc(u32, documents_in_collection);
     _ = try fh.readAll(std.mem.sliceAsBytes(lengths_vector));
 
     fh.close();
@@ -25,14 +29,14 @@ pub fn main() !void {
     fh = try std.fs.cwd().openFile("docids.bin", .{});
     var stream = std.io.bufferedReader(fh.reader());
 
-    var primary_keys = try arena.allocator().alloc([]u8, lengths_stat.size / 4);
+    var primary_keys = try arena.allocator().alloc([]u8, documents_in_collection);
 
     var docid_buf: [256]u8 = undefined;
-    var i: usize = 0;
+    var key_index: usize = 0;
     while (try stream.reader().readUntilDelimiterOrEof(&docid_buf, '\n')) |line| {
         const docid = try arena.allocator().dupe(u8, line);
-        primary_keys[i] = docid;
-        i += 1;
+        primary_keys[key_index] = docid;
+        key_index += 1;
     }
 
     fh.close();
@@ -41,7 +45,7 @@ pub fn main() !void {
     fh = try std.fs.cwd().openFile("vocab.bin", .{});
     stream = std.io.bufferedReader(fh.reader());
 
-    var vocab = std.StringHashMap(struct { i32, i32 }).init(arena.allocator());
+    var vocab = std.StringHashMap(struct { u32, u32 }).init(arena.allocator());
 
     while (true) {
         const len = stream.reader().readByte() catch |err| switch (err) {
@@ -52,8 +56,8 @@ pub fn main() !void {
         _ = stream.reader().readAll(term) catch unreachable;
         _ = stream.reader().readByte() catch unreachable;
 
-        const where = stream.reader().readInt(i32, native_endian) catch unreachable;
-        const size = stream.reader().readInt(i32, native_endian) catch unreachable;
+        const where = stream.reader().readInt(u32, native_endian) catch unreachable;
+        const size = stream.reader().readInt(u32, native_endian) catch unreachable;
 
         try vocab.put(term, .{ where, size });
     }
@@ -61,17 +65,47 @@ pub fn main() !void {
     fh.close();
 
     // Open the postings list file
+    const postings = try arena.allocator().alloc(struct { u32, u32 }, documents_in_collection * 2);
     var postings_fh = try std.fs.cwd().openFile("postings.bin", .{});
     defer postings_fh.close();
 
+    // Allocate buffers
+    var rsv = try arena.allocator().alloc(f64, documents_in_collection);
+
+    // Set up the rsv pointers
+    var rsv_pointers = try arena.allocator().alloc(usize, documents_in_collection);
+    for (0..documents_in_collection) |i| {
+        rsv_pointers[i] = i;
+    }
+
+    // Search (one query per line)
     var stdin = std.io.getStdIn().reader();
     var query_buf: [1024]u8 = undefined;
     while (try stdin.readUntilDelimiterOrEof(&query_buf, '\n')) |line| {
+        // Zero the accumulator array
+        for (0..documents_in_collection) |i| {
+            rsv[i] = 0;
+            rsv_pointers[i] = i;
+        }
+
         var it = std.mem.split(u8, line, " ");
         while (it.next()) |term| {
             if (vocab.get(term)) |pair| {
-                std.debug.print("{} {}\n", pair);
+                try postings_fh.seekTo(pair[0]);
+                _ = try fh.readAll(std.mem.sliceAsBytes(postings)[0..pair[1]]);
+
+                const idf = @log(@as(f64, @floatFromInt(documents_in_collection)) / @as(f64, @floatFromInt(pair[1] / 8)));
+
+                for (postings, 0..) |p, i| {
+                    if (i == pair[1] / 8) break;
+                    const docid = p[0];
+                    const tf: f64 = @floatFromInt(p[1]);
+                    rsv[docid] = idf * tf * (k1 + 1) / (tf + k1 * (1 - b + b * (@as(f64, @floatFromInt(lengths_vector[docid])) / average_document_length)));
+                }
             }
+        }
+        for (rsv) |r| {
+            if (r > 0) std.debug.print("{}\n", .{r});
         }
     }
 }

--- a/JASSjr_search.zig
+++ b/JASSjr_search.zig
@@ -93,8 +93,9 @@ pub fn main() !void {
 
         const query_id = 0;
 
-        var it = std.mem.split(u8, line, " ");
+        var it = std.mem.splitAny(u8, line, " \r\n");
         while (it.next()) |term| {
+            if (term.len == 0) continue;
             // Does the term exist in the collection?
             if (vocab.get(term)) |pair| {
                 // Seek and read the postings list

--- a/JASSjr_search.zig
+++ b/JASSjr_search.zig
@@ -11,6 +11,7 @@ fn compare_rsv(rsv: []f64, first: usize, second: usize) bool {
     return if (rsv[first] == rsv[second]) first > second else rsv[first] > rsv[second];
 }
 
+// Simple search engine ranking on BM25.
 pub fn main() !void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
 
@@ -93,6 +94,7 @@ pub fn main() !void {
 
         var it = std.mem.splitAny(u8, line, " \r\n");
 
+        // If the first token is a number then assume a TREC query number, and skip it
         const query_id = std.fmt.parseInt(isize, it.peek().?, 10) catch 0;
         if (query_id != 0) _ = it.next();
 

--- a/JASSjr_search.zig
+++ b/JASSjr_search.zig
@@ -28,6 +28,7 @@ const StringContext = struct {
 // Simple search engine ranking on BM25.
 pub fn main() !void {
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    const stdout = std.io.getStdOut().writer();
 
     // Read the document lengths
     var fh = try std.fs.cwd().openFile("lengths.bin", .{});
@@ -140,7 +141,7 @@ pub fn main() !void {
         // query-id Q0 document-id rank score run-name
         for (rsv_pointers, 0..) |r, i| {
             if (rsv[r] == 0 or i == 1000) break;
-            if (r > 0) std.debug.print("{d} Q0 {s} {d} {d:.4} JASSjr\n", .{ query_id, primary_keys[r], i + 1, rsv[r] });
+            try stdout.print("{d} Q0 {s} {d} {d:.4} JASSjr\n", .{ query_id, primary_keys[r], i + 1, rsv[r] });
         }
     }
 }

--- a/JASSjr_search.zig
+++ b/JASSjr_search.zig
@@ -91,9 +91,11 @@ pub fn main() !void {
             rsv[i] = 0;
         }
 
-        const query_id = 0;
-
         var it = std.mem.splitAny(u8, line, " \r\n");
+
+        const query_id = std.fmt.parseInt(isize, it.peek().?, 10) catch 0;
+        if (query_id != 0) _ = it.next();
+
         while (it.next()) |term| {
             if (term.len == 0) continue;
             // Does the term exist in the collection?

--- a/JASSjr_search.zig
+++ b/JASSjr_search.zig
@@ -1,0 +1,77 @@
+// Copyright (c) 2024 Vaughan Kitchen
+// Minimalistic BM25 search engine.
+
+const std = @import("std");
+const native_endian = @import("builtin").target.cpu.arch.endian();
+
+pub fn main() !void {
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+
+    // Read the document lengths
+    var fh = try std.fs.cwd().openFile("lengths.bin", .{});
+
+    const lengths_stat = try fh.stat();
+    const lengths_vector = try arena.allocator().alloc(i32, lengths_stat.size / 4);
+    _ = try fh.readAll(std.mem.sliceAsBytes(lengths_vector));
+
+    fh.close();
+
+    // Compute the average document length for BM25
+    var average_document_length: f64 = 0;
+    for (lengths_vector) |val| average_document_length += @floatFromInt(val);
+    average_document_length /= @floatFromInt(lengths_vector.len);
+
+    // Read the primary keys
+    fh = try std.fs.cwd().openFile("docids.bin", .{});
+    var stream = std.io.bufferedReader(fh.reader());
+
+    var primary_keys = try arena.allocator().alloc([]u8, lengths_stat.size / 4);
+
+    var docid_buf: [256]u8 = undefined;
+    var i: usize = 0;
+    while (try stream.reader().readUntilDelimiterOrEof(&docid_buf, '\n')) |line| {
+        const docid = try arena.allocator().dupe(u8, line);
+        primary_keys[i] = docid;
+        i += 1;
+    }
+
+    fh.close();
+
+    // Build the vocabulary in memory
+    fh = try std.fs.cwd().openFile("vocab.bin", .{});
+    stream = std.io.bufferedReader(fh.reader());
+
+    var vocab = std.StringHashMap(struct { i32, i32 }).init(arena.allocator());
+
+    while (true) {
+        const len = stream.reader().readByte() catch |err| switch (err) {
+            error.EndOfStream => break,
+            else => return err,
+        };
+        const term = try arena.allocator().alloc(u8, len);
+        _ = stream.reader().readAll(term) catch unreachable;
+        _ = stream.reader().readByte() catch unreachable;
+
+        const where = stream.reader().readInt(i32, native_endian) catch unreachable;
+        const size = stream.reader().readInt(i32, native_endian) catch unreachable;
+
+        try vocab.put(term, .{ where, size });
+    }
+
+    fh.close();
+
+    // Open the postings list file
+    var postings_fh = try std.fs.cwd().openFile("postings.bin", .{});
+    defer postings_fh.close();
+
+    var stdin = std.io.getStdIn().reader();
+    var query_buf: [1024]u8 = undefined;
+    while (try stdin.readUntilDelimiterOrEof(&query_buf, '\n')) |line| {
+        var it = std.mem.split(u8, line, " ");
+        while (it.next()) |term| {
+            if (vocab.get(term)) |pair| {
+                std.debug.print("{} {}\n", pair);
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ These are for example purposes only. Each implementation is intending to be idio
 | Python   | 3.12.2                    | Regex  | Array        | 74s      | 850ms  |
 | Raku     | v6.d/2023.11              | Regex  | Array        | 140min   | 8s     |
 | Ruby     | 3.3.2                     | Regex  | Array        | 160s     | 2.3s   |
-| Zig      | 0.12.0-dev.3639+9cfac4718 | Lexer  | Array        | 8s       | 100ms  |
+| Zig      | 0.12.0-dev.3639+9cfac4718 | Lexer  | Array        | 8s       | 130ms  |
 
 Where Parser is one of
 * Lexer being a hand written single token look-ahead lexer

--- a/README.md
+++ b/README.md
@@ -22,9 +22,13 @@ As an example ranking function this code implements the ATIRE version of BM25 wi
 * There are many variants of BM25, JASSjr uses the ATIRE BM25 function which ignores the k3 query component.  It is assumed that each term is unique and occurs only once (and so the k3 clause is set to 1.0).
 
 # Usage #
-To build simply use
+To build for C++ and Java simply use
 
 	make
+
+or for all compiled languages use
+
+    make all
 
 To index use
 
@@ -155,6 +159,8 @@ So JASSjr is not as fast as JASSv2, and not quite as good at ranking as JASSv2, 
 | JASSjr_search.raku | Raku source code to search engine |
 | JASSjr_index.nim | Nim source code to indexer |
 | JASSjr_search.nim | Nim source code to search engine |
+| JASSjr_index.zig | Zig source code to indexer |
+| JASSjr_search.zig | Zig source code to search engine |
 | GNUmakefile | GNU make makefile for macOS / Linux |
 | makefile | NMAKE makefile for Windows |
 | test_documents.xml | Example of how documents should be layed out for indexing | 
@@ -167,18 +173,19 @@ There are lies, damned lies, and benchmarks
 
 These are for example purposes only. Each implementation is intending to be idiomatic in its source language rather than to eek out every last bit of performance. That being said if there are equal implementation choices the faster version is preferred when possible. Benchmarking was done on an Intel Core i7-7700k @ 4.20GHz with 64GiB 3000MHz DDR4 running Musl Void Linux 6.6.23 or newer.
 
-| Language | Version            | Parser | Accumulators | Indexing | Search |
-| -------- | -------            |------- | ------------ | -------- | ------ |
-| C++      | gcc 13.2           | Lexer  | Array        | 15s      | 280ms  |
-| Elixir   | 1.15.7/erts-14.2.3 | Lexer  | HashMap      | 125s     | 850ms  |
-| Go       | 1.22.0             | Lexer  | Array        | 18s      | 250ms  |
-| Java     | 1.8.0_332          | Lexer  | Array        | 18s      | 330ms  |
-| JS       | node v18.19.1      | Regex  | Array        | 35s      | 750ms  |
-| Nim      | 2.0.0              | Regex  | Array        | 19s      | 950ms  |
-| Perl     | v5.38.2            | Regex  | Array        | 115s     | 900ms  |
-| Python   | 3.12.2             | Regex  | Array        | 74s      | 850ms  |
-| Raku     | v6.d/2023.11       | Regex  | Array        | 140min   | 8s     |
-| Ruby     | 3.3.2              | Regex  | Array        | 160s     | 2.3s   |
+| Language | Version                   | Parser | Accumulators | Indexing | Search |
+| -------- | -------                   |------- | ------------ | -------- | ------ |
+| C++      | c++11/gcc 13.2            | Lexer  | Array        | 15s      | 280ms  |
+| Elixir   | 1.15.7/erts-14.2.3        | Lexer  | HashMap      | 125s     | 850ms  |
+| Go       | 1.22.0                    | Lexer  | Array        | 18s      | 250ms  |
+| Java     | 1.8.0_332                 | Lexer  | Array        | 18s      | 330ms  |
+| JS       | node v18.19.1             | Regex  | Array        | 35s      | 750ms  |
+| Nim      | 2.0.0                     | Regex  | Array        | 19s      | 950ms  |
+| Perl     | v5.38.2                   | Regex  | Array        | 115s     | 900ms  |
+| Python   | 3.12.2                    | Regex  | Array        | 74s      | 850ms  |
+| Raku     | v6.d/2023.11              | Regex  | Array        | 140min   | 8s     |
+| Ruby     | 3.3.2                     | Regex  | Array        | 160s     | 2.3s   |
+| Zig      | 0.12.0-dev.3639+9cfac4718 | Lexer  | Array        | 8.25s    | 100ms  |
 
 Where Parser is one of
 * Lexer being a hand written single token look-ahead lexer

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ These are for example purposes only. Each implementation is intending to be idio
 | Python   | 3.12.2                    | Regex  | Array        | 74s      | 850ms  |
 | Raku     | v6.d/2023.11              | Regex  | Array        | 140min   | 8s     |
 | Ruby     | 3.3.2                     | Regex  | Array        | 160s     | 2.3s   |
-| Zig      | 0.12.0-dev.3639+9cfac4718 | Lexer  | Array        | 8.25s    | 100ms  |
+| Zig      | 0.12.0-dev.3639+9cfac4718 | Lexer  | Array        | 8s       | 100ms  |
 
 Where Parser is one of
 * Lexer being a hand written single token look-ahead lexer


### PR DESCRIPTION
Zig is an imperative systems programming which aims to be a successor to C. It's "killer" features are comptime where Zig code can be executed during compilation for uses such as generating generics or metaprogramming, it's ability to directly import C libraries making it simple to write bindings, and the focus on explicit allocation in the stdlib ensuring predictable performance

Unlike other C replacement languages Zig intends to maintain the simplicity of C by having few language features

I have verified the indexer in the usual way of comparing docids.bin, lengths.bin and the sizes of postings.bin and vocab.bin as well as running the 51-100.titles.txt queries and comparing the output

I have again verified the search by running the 51-100.titles.txt queries and comparing the output

Here are some timing against the baseline on my i7-7700k: 
| | Time to index (s) | Time for one query (ms) | Time for 50 queries (ms) |
| - | - | - | - |
| C++ | 15 | 300 | 700 |
| Zig | 8 | 130 | 530 |