### PR TITLE
Rename length_vector -> doc_lengths

### DIFF
--- a/JASSjr_index.cpp
+++ b/JASSjr_index.cpp
@@ -22,7 +22,7 @@ char *current;													// where the lexical analyser is in buffer[]
 char next_token[1024 * 1024];									// the token we're currently building
 std::unordered_map<std::string, postings_list> vocab;			// the in-memory index
 std::vector<std::string>doc_ids;								// the primary keys
-std::vector<int32_t> length_vector;								// hold the length of each document
+std::vector<int32_t> doc_lengths;								// hold the length of each document
 
 /*
 	LEX_GET_NEXT()
@@ -111,7 +111,7 @@ int main(int argc, const char *argv[])
 					Save the previous document length
 				*/
 				if (docid != -1)
-					length_vector.push_back(document_length);
+					doc_lengths.push_back(document_length);
 
 				/*
 					Move on to the next document
@@ -176,14 +176,14 @@ int main(int argc, const char *argv[])
 		return 0;
 
 	/*
+		Save the final document length
+	*/
+	doc_lengths.push_back(document_length);
+
+	/*
 		tell the user we've got to the end of parsing
 	*/
 	std::cout << "Indexed " << docid + 1 << " documents. Serialising...\n";
-
-	/*
-		Save the final document length
-	*/
-	length_vector.push_back(document_length);
 
 	/*
 		store the primary keys
@@ -221,7 +221,7 @@ int main(int argc, const char *argv[])
 		store the document lengths
 	*/
 	FILE *lengths_fp = fopen("lengths.bin", "w+b");
-	fwrite(&length_vector[0], sizeof(length_vector[0]), length_vector.size(), lengths_fp);
+	fwrite(&doc_lengths[0], sizeof(doc_lengths[0]), doc_lengths.size(), lengths_fp);
 
 	/*
 		clean up

--- a/JASSjr_index.d
+++ b/JASSjr_index.d
@@ -65,7 +65,7 @@ int main(string[] argv)
 
 	Posting[][string] vocab;
 	string[] doc_ids;
-	int[] length_vector;
+	int[] doc_lengths;
 
 	auto docid = -1;
 	auto document_length = 0;
@@ -89,7 +89,7 @@ int main(string[] argv)
 			{
 				// Save the previous document length
 				if (docid != -1)
-					length_vector ~= document_length;
+					doc_lengths ~= document_length;
 
 				// Move on to the next document
 				docid++;
@@ -135,7 +135,7 @@ int main(string[] argv)
 	}
 
 	// Save the final document length
-	length_vector ~= document_length;
+	doc_lengths ~= document_length;
 
 	// Tell the user we've got to the end of parsing
 	writefln("Indexed %d documents. Serialising", docid+1);
@@ -166,7 +166,7 @@ int main(string[] argv)
 
 
 	// Store the document lengths
-	File("lengths.bin", "w").rawWrite(length_vector);
+	File("lengths.bin", "w").rawWrite(doc_lengths);
 
 	return 0;
 }

--- a/JASSjr_index.exs
+++ b/JASSjr_index.exs
@@ -8,7 +8,7 @@
 defmodule Index do
   defstruct length: 0, # length of currently indexing document
   docno: 0, # cache last index into primary keys
-  lengths: [], # hold the length of each document
+  doclengths: [], # hold the length of each document
   docnos: [], # the primary keys
   terms: %{} # the in-memory index (terms => <tf, docid>)
 
@@ -50,7 +50,7 @@ defmodule Indexer do
 
       # Move on to the next document
       index = if index.docno > 0 do
-        %Index{index | length: 0, lengths: [ index.length | index.lengths], docno: index.docno + 1, docnos: [ docno | index.docnos]}
+        %Index{index | length: 0, doclengths: [ index.length | index.doclengths], docno: index.docno + 1, docnos: [ docno | index.docnos]}
       else
         %Index{index | docno: index.docno + 1, docnos: [ docno | index.docnos]}
       end
@@ -103,7 +103,7 @@ defmodule Indexer do
   # serialise the in-memory index to disk
   def serialise(index) do
     # Save the final document length
-    index = %Index{index | lengths: [ index.length | index.lengths]}
+    index = %Index{index | doclengths: [ index.length | index.doclengths]}
     docnos = Enum.reverse(index.docnos)
 
     # store the primary keys
@@ -127,11 +127,11 @@ defmodule Indexer do
     :ok = File.close(postings)
     :ok = File.close(vocab)
 
-    # store the document lengths
-    lengths = Enum.reverse(index.lengths)
-    lengths = for x <- lengths, do: <<x::native-32>>, into: <<>>
+    # store the document doclengths
+    doclengths = Enum.reverse(index.doclengths)
+    doclengths = for x <- doclengths, do: <<x::native-32>>, into: <<>>
     File.open!("lengths.bin", [:write], fn file ->
-      IO.binwrite(file, lengths)
+      IO.binwrite(file, doclengths)
     end)
   end
 end

--- a/JASSjr_index.f90
+++ b/JASSjr_index.f90
@@ -387,7 +387,7 @@ program index
         type(lexer_class) :: lexer
         type(vocab_class) :: vocab
         type(dynarray_string_class) :: doc_ids
-        type(dynarray_integer_class) :: length_vector
+        type(dynarray_integer_class) :: doc_lengths
         integer :: argc, docid, document_length
         integer :: rc ! return code
         logical :: push_next
@@ -414,7 +414,7 @@ program index
         push_next = .FALSE.
         call vocab%init()
         call doc_ids%init()
-        call length_vector%init()
+        call doc_lengths%init()
 
         ! Read the file line by line
         do
@@ -429,7 +429,7 @@ program index
                         ! If we see a <DOC> tag then we're at the start of the next document
                         if (token == '<DOC>') then
                                 ! Save the previous document length
-                                if (docid /= -1) call length_vector%append(document_length)
+                                if (docid /= -1) call doc_lengths%append(document_length)
                                 ! Move on to the next document
                                 docid = docid + 1
                                 document_length = 0
@@ -458,7 +458,7 @@ program index
         if (docid == -1) stop
 
         ! Save the final document length
-        call length_vector%append(document_length)
+        call doc_lengths%append(document_length)
 
         ! Tell the user we've got to the end of parsing
         print '(A, I0, A)', 'Indexed ', docid + 1, ' documents. Serialising...'
@@ -478,7 +478,7 @@ program index
         ! Store the document lengths
         open (unit=14, action='write', file='lengths.bin', iostat=rc, status='replace', access='stream')
         if (rc /= 0) stop 'ERROR: open failed'
-        call length_vector%write(14)
+        call doc_lengths%write(14)
 
         ! Clean up
         close (10)

--- a/JASSjr_index.f90
+++ b/JASSjr_index.f90
@@ -246,7 +246,7 @@ contains
                 do while (allocated(this%store(i)%term))
                         if (this%store(i)%term == term) then
                                 ! If the docno for this occurence has changed then create a new <d,tf> pair
-                                if (this%store(i)%postings%at(-2) != docid) then
+                                if (this%store(i)%postings%at(-2) /= docid) then
                                         call this%store(i)%postings%append(docid)
                                         call this%store(i)%postings%append(1)
                                         return

--- a/JASSjr_index.go
+++ b/JASSjr_index.go
@@ -93,7 +93,7 @@ Simple indexer for TREC WSJ collection
 func main() {
 	vocab := make(map[string][]posting)
 	docIds := make([]string, 0)
-	lengthVector := make([]int32, 0)
+	docLengths := make([]int32, 0)
 
 	var docId int32 = -1
 	var documentLength int32 = 0
@@ -121,7 +121,7 @@ func main() {
 					Save the previous document length
 				*/
 				if docId != -1 {
-					lengthVector = append(lengthVector, documentLength)
+					docLengths = append(docLengths, documentLength)
 				}
 
 				/*
@@ -190,7 +190,7 @@ func main() {
 	/*
 		Save the final document length
 	*/
-	lengthVector = append(lengthVector, documentLength)
+	docLengths = append(docLengths, documentLength)
 
 	/*
 		tell the user we've got to the end of parsing
@@ -259,6 +259,6 @@ func main() {
 	defer docLengthsFile.Close()
 	docLengthsWriter := bufio.NewWriter(docLengthsFile)
 	defer docLengthsWriter.Flush()
-	err = binary.Write(docLengthsWriter, binary.NativeEndian, lengthVector)
+	err = binary.Write(docLengthsWriter, binary.NativeEndian, docLengths)
 	check(err)
 }

--- a/JASSjr_index.java
+++ b/JASSjr_index.java
@@ -47,7 +47,7 @@ class JASSjr_index
 	String nextToken;
 	HashMap<String, PostingsList> vocab = new HashMap<String, PostingsList>();
 	ArrayList<String> docIds = new ArrayList<String>();
-	ArrayList<Integer> lengthVector = new ArrayList<Integer>();
+	ArrayList<Integer> docLengths = new ArrayList<Integer>();
 
 	/* 
 		toNativeEndian()
@@ -135,7 +135,7 @@ class JASSjr_index
 						  Save the previous document length
 						*/
 						if (docId != -1)
-							lengthVector.add(documentLength);
+							docLengths.add(documentLength);
 			
 						/*
 						  Move on to the next document
@@ -196,16 +196,16 @@ class JASSjr_index
 					documentLength++;
 					}
 				}
-	
+
+		/*
+		  Save the final document length
+		*/
+		docLengths.add(documentLength);
+
 		/*
 		  tell the user we've got to the end of parsing
 		*/
 		System.out.println("Indexed " + (docId + 1) + " documents. Serialising...");
-	
-		/*
-		  Save the final document length
-		*/
-		lengthVector.add(documentLength);
 
 			/*
 			  store the primary keys
@@ -261,12 +261,12 @@ class JASSjr_index
 			  store the document lengths
 			*/
 			DataOutputStream docLengthsFile = new DataOutputStream(new FileOutputStream("lengths.bin"));
-			for (int i= 0; i < lengthVector.size(); i++)
-				linear[i] = lengthVector.get(i);
+			for (int i= 0; i < docLengths.size(); i++)
+				linear[i] = docLengths.get(i);
 		
 			intBuffer.rewind();
-			intBuffer.put(linear, 0, lengthVector.size());
-			docLengthsFile.write(byteBuffer.array(), 0, lengthVector.size() * 4);
+			intBuffer.put(linear, 0, docLengths.size());
+			docLengthsFile.write(byteBuffer.array(), 0, docLengths.size() * 4);
 		   
 			/*
 			  clean up

--- a/JASSjr_index.js
+++ b/JASSjr_index.js
@@ -16,7 +16,7 @@ if (process.argv.length != 3) {
 
 var vocab = {}; // the in-memory index
 var doc_ids = []; // the primary keys
-var length_vector = []; // hold the length of each document
+var doc_lengths = []; // hold the length of each document
 
 var docid = -1;
 var document_length = 0;
@@ -39,7 +39,7 @@ rl.on('line', function (line) {
 		if (token == '<DOC>') {
 			// Save the previous document length
 			if (docid != -1)
-				length_vector.push(document_length);
+				doc_lengths.push(document_length);
 			// Move on to the next document
 			docid++;
 			document_length = 0;
@@ -87,17 +87,17 @@ rl.on('close', function () {
 	if (docid == -1)
 		process.exit(0);
 
+	// Save the final document length
+	doc_lengths.push(document_length);
+
 	// tell the user we've got to the end of parsing
 	console.log('Indexed %d documents. Serialising...', docid + 1);
-
-	// Save the final document length
-	length_vector.push(document_length);
 
 	// store the primary keys
 	fs.writeFileSync('docids.bin', doc_ids.join(os.EOL) + '\n');
 
 	// store the document lengths
-	fs.writeFileSync('lengths.bin', Uint32Array.from(length_vector));
+	fs.writeFileSync('lengths.bin', Uint32Array.from(doc_lengths));
 
 	var postings_fd = fs.createWriteStream('postings.bin');
 	var vocab_fd = fs.createWriteStream('vocab.bin');

--- a/JASSjr_index.nim
+++ b/JASSjr_index.nim
@@ -18,7 +18,7 @@ if paramCount() != 1:
 
 var vocab = initTable[string, seq[int32]]() # the in-memory index
 var doc_ids: seq[string] # the primary keys
-var length_vector: seq[int32] # hold the length of each document
+var doc_lengths: seq[int32] # hold the length of each document
 
 # A token is either an XML tag '<'..'>' or a sequence of alpha-numerics.
 # TREC <DOCNO> primary keys have a hyphen in them
@@ -34,7 +34,7 @@ for line in lines(commandLineParams()[0]):
     if token == "<DOC>":
       # Save the previous document length
       if docid != -1:
-        length_vector.add(document_length)
+        doc_lengths.add(document_length)
       # Move on to the next document
       docid += 1
       document_length = 0
@@ -78,7 +78,7 @@ if docid == -1:
   quit()
 
 # Save the final document length
-length_vector.add(document_length)
+doc_lengths.add(document_length)
 
 # tell the user we've got to the end of parsing
 echo(fmt"Indexed { docid + 1 } documents. Serialising...")
@@ -105,7 +105,7 @@ for term, postings in vocab.pairs():
 
 # store the document lengths
 let doc_lengths_strm = newFileStream("lengths.bin", fmWrite)
-doc_lengths_strm.writeData(addr(length_vector[0]), len(length_vector) * sizeof(length_vector[0]))
+doc_lengths_strm.writeData(addr(doc_lengths[0]), len(doc_lengths) * sizeof(doc_lengths[0]))
 
 # clean up
 docids_fh.close()

--- a/JASSjr_index.pl
+++ b/JASSjr_index.pl
@@ -14,7 +14,7 @@ die "Usage: $0 <infile.xml>" if scalar @ARGV != 1;
 
 my %vocab; # the in-memory index
 my @doc_ids; # the primary keys
-my @length_vector; # hold the length of each document
+my @doc_lengths; # hold the length of each document
 
 my $docid = -1;
 my $document_length = 0;
@@ -27,7 +27,7 @@ while (<>) {
 		# If we see a <DOC> tag then we're at the start of the next document
 		if ($_ eq '<DOC>') {
 			# Save the previous document length
-			push @length_vector, $document_length if $docid != -1;
+			push @doc_lengths, $document_length if $docid != -1;
 			# Move on to the next document
 			$docid += 1;
 			$document_length = 0;
@@ -65,7 +65,7 @@ while (<>) {
 exit if $docid == -1;
 
 # Save the final document length
-push @length_vector, $document_length;
+push @doc_lengths, $document_length;
 
 # tell the user we've got to the end of parsing
 say "Indexed @{[$docid + 1]} documents. Serialising...";
@@ -92,7 +92,7 @@ while (my ($term, $postings) = each %vocab) {
 
 # store the document lengths
 open my $lengths_fh, '>:raw', 'lengths.bin' or die;
-print $lengths_fh pack 'l*', @length_vector;
+print $lengths_fh pack 'l*', @doc_lengths;
 
 # clean up
 close $docids_fh;

--- a/JASSjr_index.py
+++ b/JASSjr_index.py
@@ -16,7 +16,7 @@ if len(sys.argv) != 2:
 
 vocab = defaultdict(lambda: array('i')) # the in-memory index
 doc_ids = [] # the primary keys
-length_vector = array('i') # hold the length of each document
+doc_lengths = array('i') # hold the length of each document
 
 # A token is either an XML tag '<'..'>' or a sequence of alpha-numerics.
 # TREC <DOCNO> primary keys have a hyphen in them
@@ -33,7 +33,7 @@ with open(sys.argv[1], 'r') as file:
             if token == "<DOC>":
                 # Save the previous document length
                 if docid != -1:
-                    length_vector.append(document_length)
+                    doc_lengths.append(document_length)
                 # Move on to the next document
                 docid += 1
                 document_length = 0
@@ -72,11 +72,11 @@ with open(sys.argv[1], 'r') as file:
 if docid == -1:
     sys.exit()
 
+# Save the final document length
+doc_lengths.append(document_length)
+
 # tell the user we've got to the end of parsing
 print(f"Indexed {docid + 1} documents. Serialising...")
-
-# Save the final document length
-length_vector.append(document_length)
 
 # store the primary keys
 with open("docids.bin", "w") as file:
@@ -101,7 +101,7 @@ for term, postings in vocab.items():
 
 # store the document lengths
 with open("lengths.bin", "wb") as file:
-    length_vector.tofile(file)
+    doc_lengths.tofile(file)
 
 # clean up
 postings_fp.close()

--- a/JASSjr_index.raku
+++ b/JASSjr_index.raku
@@ -10,7 +10,7 @@ if @*ARGS.elems != 1 {
 
 my %vocab; # the in-memory index
 my @doc_ids; # the primary keys
-my @length_vector; # hold the length of each document
+my @doc_lengths; # hold the length of each document
 
 my $docid = -1;
 my $document_length = 0;
@@ -24,7 +24,7 @@ for @*ARGS[0].IO.lines -> $line {
 		# If we see a <DOC> tag then we're at the start of the next document
 		if $token eq '<DOC>' {
 			# Save the previous document length
-			@length_vector.push($document_length) if $docid != -1;
+			@doc_lengths.push($document_length) if $docid != -1;
 			# Move on to the next document
 			$docid++;
 			$document_length = 0;
@@ -64,7 +64,7 @@ for @*ARGS[0].IO.lines -> $line {
 exit if $docid == -1;
 
 # Save the final document length
-@length_vector.push($document_length);
+@doc_lengths.push($document_length);
 
 # tell the user we've got to the end of parsing
 say("Indexed {$docid+1} documents. Serialising...");
@@ -105,7 +105,7 @@ $buffer.reallocate(0);
 
 # store the document lengths
 my $lengths_fh = open('lengths.bin', :w, :bin);
-for @length_vector {
+for @doc_lengths {
 	$buffer.write-int32(0, $_);
 	$lengths_fh.write($buffer);
 }

--- a/JASSjr_index.rb
+++ b/JASSjr_index.rb
@@ -8,7 +8,7 @@ abort("Usage: #{$0} <infile.xml>") if ARGV.length != 1
 
 vocab = {} # the in-memory index
 doc_ids = [] # the primary keys
-length_vector = [] # hold the length of each document
+doc_lengths = [] # hold the length of each document
 
 docid = -1
 document_length = 0
@@ -21,7 +21,7 @@ File.foreach(ARGV[0]) do |line|
     # If we see a <DOC> tag then we're at the start of the next document
     if token == "<DOC>"
       # Save the previous document length
-      length_vector << document_length if docid != -1
+      doc_lengths << document_length if docid != -1
       # Move on to the next document
       docid += 1
       document_length = 0
@@ -59,11 +59,11 @@ end
 # If we didn't index any documents then we're done.
 exit if docid == -1
 
+# Save the final document length
+doc_lengths << document_length
+
 # tell the user we've got to the end of parsing
 puts("Indexed #{docid + 1} documents. Serialising...")
-
-# Save the final document length
-length_vector << document_length
 
 # store the primary keys
 File.open("docids.bin", "w") { |file| file.puts(doc_ids) }
@@ -84,7 +84,7 @@ vocab.each do |term, postings|
 end
 
 # store the document lengths
-File.open("lengths.bin", "w") { |file| file.write(length_vector.pack("l*")) }
+File.open("lengths.bin", "w") { |file| file.write(doc_lengths.pack("l*")) }
 
 # clean up
 postings_fp.close

--- a/JASSjr_index.zig
+++ b/JASSjr_index.zig
@@ -56,7 +56,7 @@ pub fn main() !void {
 
     var vocab = std.StringHashMap(std.ArrayList(Posting)).init(arena.allocator());
     var doc_ids = std.ArrayList([]u8).init(arena.allocator());
-    var lengths_vector = std.ArrayList(i32).init(arena.allocator());
+    var doc_lengths = std.ArrayList(i32).init(arena.allocator());
 
     var doc_id: i32 = -1;
     var document_length: i32 = 0;
@@ -72,7 +72,7 @@ pub fn main() !void {
             if (std.mem.eql(u8, token, "<DOC>")) {
                 // Save the previous document length
                 if (doc_id != -1)
-                    try lengths_vector.append(document_length);
+                    try doc_lengths.append(document_length);
                 // Move on to the next document
                 doc_id += 1;
                 document_length = 0;
@@ -122,7 +122,7 @@ pub fn main() !void {
     }
 
     // Save the final document length
-    try lengths_vector.append(document_length);
+    try doc_lengths.append(document_length);
 
     // Tell the user we've got to the end of parsing
     try stdout.print("Indexed {d} documents. Serialising...\n", .{doc_id + 1});
@@ -162,7 +162,7 @@ pub fn main() !void {
     // Store the document lengths
     const lengths_fh = try std.fs.cwd().createFile("lengths.bin", .{});
     var lengths_stream = std.io.bufferedWriter(lengths_fh.writer());
-    try lengths_stream.writer().writeAll(std.mem.sliceAsBytes(lengths_vector.items));
+    try lengths_stream.writer().writeAll(std.mem.sliceAsBytes(doc_lengths.items));
 
     // Cleanup
     try lengths_stream.flush();

--- a/JASSjr_search.cpp
+++ b/JASSjr_search.cpp
@@ -88,7 +88,7 @@ int main(int argc, const char *argv[])
 	int32_t where, size, string_length;
 	char seperators[255];
 	char *into = seperators;
-	int32_t *length_vector;
+	int32_t *doc_lengths;
 
 	/*
 		Set up the tokenizer seperator characters
@@ -103,7 +103,7 @@ int main(int argc, const char *argv[])
 	*/
 	size_t length_filesize_in_bytes;
 	double average_document_length = 0;
-	length_vector = reinterpret_cast<int32_t *>(read_entire_file("lengths.bin", length_filesize_in_bytes));
+	doc_lengths = reinterpret_cast<int32_t *>(read_entire_file("lengths.bin", length_filesize_in_bytes));
 	if (length_filesize_in_bytes == 0)
 		exit(printf("Could not find an index in the current directory\n"));
 
@@ -113,7 +113,7 @@ int main(int argc, const char *argv[])
 	double documents_in_collection = length_filesize_in_bytes / sizeof(int32_t);
 	int32_t max_docs = static_cast<int32_t>(documents_in_collection);
 	for (int32_t document = 0; document < max_docs; document++)
-		average_document_length += length_vector[document];
+		average_document_length += doc_lengths[document];
 	average_document_length /= documents_in_collection;
 
 	/*
@@ -216,7 +216,7 @@ int main(int argc, const char *argv[])
 						{
 						int32_t d = list->first;
 						int32_t tf = list->second;
-						rsv[d] += idf * ((tf * (k1 + 1)) / (tf + k1 * (1 - b + b * (length_vector[d] / average_document_length))));
+						rsv[d] += idf * ((tf * (k1 + 1)) / (tf + k1 * (1 - b + b * (doc_lengths[d] / average_document_length))));
 						}
 					}
 				}

--- a/JASSjr_search.d
+++ b/JASSjr_search.d
@@ -27,10 +27,10 @@ const auto b = 0.4;  // BM25 b parameter
 void main(string[] argv)
 {
 	// Read the document lengths
-	auto document_lengths = cast(int[]) read("lengths.bin");
+	auto doc_lengths = cast(int[]) read("lengths.bin");
 
 	// Compute the average document length for BM25
-	auto average_document_length = cast(double) sum(document_lengths) / cast(double) document_lengths.length;
+	auto average_document_length = cast(double) sum(doc_lengths) / cast(double) doc_lengths.length;
 
 	// Read the primary keys
 	auto primary_keys = File("docids.bin").byLineCopy().array();
@@ -95,7 +95,7 @@ void main(string[] argv)
 			foreach (Tuple!(int, int) post; postings[0 .. postings_length])
 			{
 				auto docid = post[0], tf = cast(double) post[1];
-				rsv[docid] += idf * tf * (k1 + 1) / (tf + k1 * (1 - b + b * (cast(double) document_lengths[docid] / average_document_length)));
+				rsv[docid] += idf * tf * (k1 + 1) / (tf + k1 * (1 - b + b * (cast(double) doc_lengths[docid] / average_document_length)));
 			}
 		}
 

--- a/JASSjr_search.go
+++ b/JASSjr_search.go
@@ -52,16 +52,16 @@ func main() {
 	*/
 	lengthsAsBytes, err := os.ReadFile("lengths.bin")
 	check(err)
-	lengthVector := make([]int32, len(lengthsAsBytes)/4)
-	err = binary.Read(bytes.NewReader(lengthsAsBytes), binary.NativeEndian, lengthVector)
+	docLengths := make([]int32, len(lengthsAsBytes)/4)
+	err = binary.Read(bytes.NewReader(lengthsAsBytes), binary.NativeEndian, docLengths)
 	check(err)
 
 	/*
 	  Compute the average document length for BM25
 	*/
-	documentsInCollection := len(lengthVector)
+	documentsInCollection := len(docLengths)
 	var averageDocumentLength float64 = 0
-	for _, which := range lengthVector {
+	for _, which := range docLengths {
 		averageDocumentLength += float64(which)
 	}
 	averageDocumentLength /= float64(documentsInCollection)
@@ -173,7 +173,7 @@ func main() {
 			for i := 0; i < len(currentList); i += 2 {
 				d := currentList[i]
 				tf := float64(currentList[i+1])
-				rsv[d] += idf * ((tf * (k1 + 1)) / (tf + k1*(1-b+b*(float64(lengthVector[d])/averageDocumentLength))))
+				rsv[d] += idf * ((tf * (k1 + 1)) / (tf + k1*(1-b+b*(float64(docLengths[d])/averageDocumentLength))))
 			}
 		}
 		/*

--- a/JASSjr_search.java
+++ b/JASSjr_search.java
@@ -98,15 +98,15 @@ class JASSjr_search
 			}
 		lengthsAsBytes.order(ByteOrder.nativeOrder());
 		IntBuffer lengthsAsIntegers = lengthsAsBytes.asIntBuffer();
-		int[] lengthVector = new int [lengthsAsBytes.capacity() / 4];
-		lengthsAsIntegers.get(lengthVector);
+		int[] docLengths = new int [lengthsAsBytes.capacity() / 4];
+		lengthsAsIntegers.get(docLengths);
 
 		/*
 		  Compute the average document length for BM25
 		*/
-		double documentsInCollection = lengthVector.length;
+		double documentsInCollection = docLengths.length;
 		double averageDocumentLength = 0;
-		for (int which : lengthVector)
+		for (int which : docLengths)
 			averageDocumentLength += which;
 		averageDocumentLength /= documentsInCollection;
 
@@ -212,7 +212,7 @@ class JASSjr_search
 							{
 							int d = currentListAsBytes.getInt();
 							int tf = currentListAsBytes.getInt();
-							rsv[d] += idf * ((tf * (k1 + 1)) / (tf + k1 * (1 - b + b * (lengthVector[d] / averageDocumentLength))));
+							rsv[d] += idf * ((tf * (k1 + 1)) / (tf + k1 * (1 - b + b * (docLengths[d] / averageDocumentLength))));
 							}
 						}
 					}

--- a/JASSjr_search.zig
+++ b/JASSjr_search.zig
@@ -37,15 +37,15 @@ pub fn main() !void {
 
     const lengths_stat = try fh.stat();
     const documents_in_collection = lengths_stat.size / 4;
-    const lengths_vector = try arena.allocator().alloc(u32, documents_in_collection);
-    _ = try fh.readAll(std.mem.sliceAsBytes(lengths_vector));
+    const doc_lengths = try arena.allocator().alloc(u32, documents_in_collection);
+    _ = try fh.readAll(std.mem.sliceAsBytes(doc_lengths));
 
     fh.close();
 
     // Compute the average document length for BM25
     var average_document_length: f64 = 0;
-    for (lengths_vector) |val| average_document_length += @floatFromInt(val);
-    average_document_length /= @floatFromInt(lengths_vector.len);
+    for (doc_lengths) |val| average_document_length += @floatFromInt(val);
+    average_document_length /= @floatFromInt(doc_lengths.len);
 
     // Read the primary keys
     fh = try std.fs.cwd().openFile("docids.bin", .{});
@@ -131,7 +131,7 @@ pub fn main() !void {
                     if (i == pair[1] / 8) break;
                     const docid = p[0];
                     const tf: f64 = @floatFromInt(p[1]);
-                    rsv[docid] += idf * tf * (k1 + 1) / (tf + k1 * (1 - b + b * (@as(f64, @floatFromInt(lengths_vector[docid])) / average_document_length)));
+                    rsv[docid] += idf * tf * (k1 + 1) / (tf + k1 * (1 - b + b * (@as(f64, @floatFromInt(doc_lengths[docid])) / average_document_length)));
                 }
             }
         }


### PR DESCRIPTION
I find this to be a clearer name of the intent and it matches the `doc_ids` name well

Also makes sure to add the final document_length to the in memory index before telling the user that indexing is done

Finally it includes a small fix for a bug introduced in fortran in #20 where I inadvertently used `!=` for not equal instead of `/=` or `.NE.` causing code to be commented out instead