### PR TITLE
Ruby performance improvements

### DIFF
--- a/JASSjr_search.rb
+++ b/JASSjr_search.rb
@@ -61,7 +61,7 @@ loop do
   end
 
   # Sort the results list. Tie break on the document ID.
-  accumulators.sort!.reverse!
+  accumulators.sort! { |a, b| a[0] == b[0] ? b[1] <=> a[1] : b[0] <=> a[0] }
 
   # Print the (at most) top 1000 documents in the results list in TREC eval format which is:
   # query-id Q0 document-id rank score run-name

--- a/JASSjr_search.rb
+++ b/JASSjr_search.rb
@@ -34,7 +34,7 @@ loop do
   break if query.nil?
 
   query_id = 0
-  accumulators = Array.new(doc_ids.length) { |i| [0, i] }
+  accumulators = Hash.new(0)
 
   # If the first token is a number then assume a TREC query number, and skip it
   begin
@@ -56,9 +56,12 @@ loop do
     # Process the postings list by simply adding the BM25 component for this document into the accumulators array
     postings.each_slice(2) do |docid, tf|
       rsv = idf * ((tf * (k1 + 1)) / (tf + k1 * (1 - b + b * (doc_lengths[docid] / average_length))))
-      accumulators[docid][0] += rsv
+      accumulators[docid] += rsv
     end
   end
+
+  # Turn the accumulators back into an array to get a stable ordering
+  accumulators = accumulators.collect { |k, v| [v, k] }
 
   # Sort the results list. Tie break on the document ID.
   accumulators.sort! { |a, b| a[0] == b[0] ? b[1] <=> a[1] : b[0] <=> a[0] }

--- a/JASSjr_search.rb
+++ b/JASSjr_search.rb
@@ -68,7 +68,7 @@ loop do
 
   # Print the (at most) top 1000 documents in the results list in TREC eval format which is:
   # query-id Q0 document-id rank score run-name
-  accumulators.take_while { |rsv, | rsv > 0 }.take(1000).each_with_index do |(rsv, docid), i|
+  accumulators.take(1000).each_with_index do |(rsv, docid), i|
     puts("#{query_id} Q0 #{doc_ids[docid]} #{i+1} #{'%.4f' % rsv} JASSjr")
   end
 end

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ These are for example purposes only. Each implementation is intending to be idio
 | PHP      | 8.3.0/Zend v4.3.0         | Regex  | HashMap      | 30s      | 350ms  |
 | Python   | 3.12.2                    | Regex  | Array        | 74s      | 850ms  |
 | Raku     | v6.d/2023.11              | Regex  | Array        | 140min   | 8s     |
-| Ruby     | 3.3.2                     | Regex  | Array        | 160s     | 2.3s   |
+| Ruby     | 3.2.4                     | Regex  | HashMap      | 160s     | 1.25s  |
 | Zig      | 0.12.0                    | Lexer  | Array        | 8s       | 130ms  |
 
 Where Parser is one of


### PR DESCRIPTION
Replaces the accumulators array with a hashmap as sort in Ruby is extremely slow (accounting for 95% of execution time). Also makes a slight improvement to the sort performance

Timings:
| | old | new |
| - | - | - |
| 1 query | 2.3s | 1.25s |
| 50 queries | 63s | 5s |