### PR TITLE
JASSjr in Crystal

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,10 +1,12 @@
 default : cpp java tools
 
-all : cpp java d_dmd d_ldc fortran zig
+all : cpp java crystal d_dmd d_ldc fortran zig
 
 cpp : JASSjr_index JASSjr_search
 
 java : JASSjr_index.class JASSjr_search.class
+
+crystal : JASSjr_index_crystal JASSjr_search_crystal
 
 d_dmd : JASSjr_index_d_dmd JASSjr_search_d_dmd
 
@@ -25,6 +27,12 @@ JASSjr_index.class : JASSjr_index.java
 
 JASSjr_search.class : JASSjr_search.java
 	javac JASSjr_search.java
+
+JASSjr_index_crystal : JASSjr_index.cr
+	crystal build --release -o JASSjr_index_crystal JASSjr_index.cr
+
+JASSjr_search_crystal : JASSjr_search.cr
+	crystal build --release -o JASSjr_search_crystal JASSjr_search.cr
 
 JASSjr_index_d_dmd : JASSjr_index.d
 	dmd -O -of=JASSjr_index_d_dmd JASSjr_index.d

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -65,6 +65,7 @@ tools:
 clean:
 	- rm JASSjr_index JASSjr_search
 	- rm 'JASSjr_index.class' 'JASSjr_search.class' 'JASSjr_index$$Posting.class' 'JASSjr_index$$PostingsList.class' 'JASSjr_search$$CompareRsv.class' 'JASSjr_search$$VocabEntry.class'
+	- rm JASSjr_index_crystal JASSjr_search_crystal
 	- rm JASSjr_index_d_dmd JASSjr_search_d_dmd JASSjr_index_d_ldc JASSjr_search_d_ldc
 	- rm JASSjr_index_fortran JASSjr_search_fortran
 	- rm JASSjr_index_zig JASSjr_search_zig

--- a/JASSjr_index.cr
+++ b/JASSjr_index.cr
@@ -1,0 +1,95 @@
+#!/usr/bin/env crystal
+
+# Copyright (c) 2024 Vaughan Kitchen
+# Minimalistic BM25 search engine.
+
+# Make sure we have one parameter, the filename
+abort("Usage: #{PROGRAM_NAME} <infile.xml>") if ARGV.size != 1
+
+vocab = {} of String => Array(Int32) # the in-memory index
+doc_ids = [] of String # the primary keys
+doc_lengths = [] of Int32 # hold the length of each document
+
+docid = -1
+document_length = 0
+push_next = false # is the next token the primary key?
+
+File.each_line(ARGV[0]) do |line|
+  # A token is either an XML tag '<'..'>' or a sequence of alpha-numerics.
+  # TREC <DOCNO> primary keys have a hyphen in them
+  line.scan(/[a-zA-Z0-9][a-zA-Z0-9-]*|<[^>]*>/).each do |token|
+    token = token.to_s
+    # If we see a <DOC> tag then we're at the start of the next document
+    if token == "<DOC>"
+      # Save the previous document length
+      doc_lengths << document_length if docid != -1
+      # Move on to the next document
+      docid += 1
+      document_length = 0
+      puts("#{docid} documents indexed") if docid % 1000 == 0
+    end
+    # If the last token we saw was a <DOCNO> then the next token is the primary key
+    if push_next
+      doc_ids << token
+      push_next = false
+    end
+    push_next = true if token == "<DOCNO>"
+    # Don't index XML tags
+    next if token[0] == '<'
+
+    # Lower case the string
+    token = token.downcase
+
+    # Truncate any long tokens at 255 charactes (so that the length can be stored first and in a single byte)
+    token = token[0, 255]
+
+    # Add the posting to the in-memory index
+    vocab[token] = [] of Int32 if !vocab[token]? # if the term isn't in the vocab yet
+    postings_list = vocab[token]
+    if postings_list.size == 0 || postings_list[-2] != docid
+      postings_list << docid << 1 # if the docno for this occurence has changed then create a new <d,tf> pair
+    else
+      postings_list[-1] += 1 # else increase the tf
+    end
+
+    # Compute the document length
+    document_length += 1
+  end
+end
+
+# If we didn't index any documents then we're done.
+exit if docid == -1
+
+# Save the final document length
+doc_lengths << document_length
+
+# Tell the user we've got to the end of parsing
+puts("Indexed #{docid + 1} documents. Serialising...")
+
+# Store the primary keys
+File.open("docids.bin", "w") do |file|
+  doc_ids.each { |docid| file.puts(docid) }
+end
+
+postings_fp = File.open("postings.bin", "wb")
+vocab_fp = File.open("vocab.bin", "wb")
+
+vocab.each do |term, postings|
+  # Write the postings list to one file
+  where = postings_fp.pos
+  postings_fp.write(postings.to_unsafe.as(UInt8*).to_slice(postings.size * sizeof(Int32)))
+
+  # Write the vocabulary to a second file (one byte length, string, '\0', 4 byte where, 4 byte size)
+  vocab_fp.write_byte(term.size.to_u8)
+  vocab_fp.write_string(term.to_slice)
+  vocab_fp.write_byte(0)
+  vocab_fp.write_bytes(where.to_i32)
+  vocab_fp.write_bytes((postings.size * 4).to_i32)
+end
+
+# Store the document lengths
+File.open("lengths.bin", "w") { |file| file.write(doc_lengths.to_unsafe.as(UInt8*).to_slice(doc_lengths.size * sizeof(Int32))) }
+
+# Clean up
+postings_fp.close
+vocab_fp.close

--- a/JASSjr_search.cr
+++ b/JASSjr_search.cr
@@ -92,7 +92,7 @@ loop do
 
   # Print the (at most) top 1000 documents in the results list in TREC eval format which is:
   # query-id Q0 document-id rank score run-name
-  accumulators.take_while { |pair| pair[1] > 0 }.each_with_index do |(rsv, docid), i|
+  accumulators.take_while { |pair| pair[0] > 0 }.each_with_index do |(rsv, docid), i|
     break if i == 1000
     puts("#{query_id} Q0 #{doc_ids[docid]} #{i+1} #{"%.4f" % rsv} JASSjr")
   end

--- a/JASSjr_search.cr
+++ b/JASSjr_search.cr
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S crystal run
+#!/usr/bin/env crystal
 
 # Copyright (c) 2024 Vaughan Kitchen
 # Minimalistic BM25 search engine.

--- a/JASSjr_search.cr
+++ b/JASSjr_search.cr
@@ -79,8 +79,7 @@ loop do
     idf = Math.log(doc_ids.size.to_f / (postings.size / 2))
 
     # Process the postings list by simply adding the BM25 component for this document into the accumulators array
-    postings.each_slice(2) do |pair|
-      docid, tf = pair
+    postings.each_slice(2) do |(docid, tf)|
       rsv = idf * ((tf * (k1 + 1)) / (tf + k1 * (1 - b + b * (doc_lengths[docid] / average_length))))
       prev = accumulators[docid]
       accumulators[docid] = {prev[0] + rsv, prev[1]}
@@ -92,7 +91,7 @@ loop do
 
   # Print the (at most) top 1000 documents in the results list in TREC eval format which is:
   # query-id Q0 document-id rank score run-name
-  accumulators.take_while { |pair| pair[0] > 0 }.each_with_index do |(rsv, docid), i|
+  accumulators.take_while { |(rsv,)| rsv > 0 }.each_with_index do |(rsv, docid), i|
     break if i == 1000
     puts("#{query_id} Q0 #{doc_ids[docid]} #{i+1} #{"%.4f" % rsv} JASSjr")
   end

--- a/JASSjr_search.cr
+++ b/JASSjr_search.cr
@@ -1,0 +1,99 @@
+#!/usr/bin/env -S crystal run
+
+# Copyright (c) 2024 Vaughan Kitchen
+# Minimalistic BM25 search engine.
+
+k1 = 0.9 # BM25 k1 parameter
+b = 0.4 # BM25 b parameter
+
+doc_ids = File.read_lines("docids.bin", chomp: true) # Read the primary_keys
+
+# Read the document lengths
+doc_lengths = [] of Int32
+File.open("lengths.bin") do |file|
+  loop do
+    doc_lengths << file.read_bytes(Int32)
+  rescue IO::EOFError
+    break
+  end
+end
+
+# Compute the average document length for BM25
+average_length = doc_lengths.sum.to_f / doc_lengths.size
+
+vocab = {} of String => Tuple(Int32, Int32)
+
+# decode the vocabulary (unsigned byte length, string, '\0', 4 byte signed where, 4 signed byte size)
+File.open("vocab.bin") do |file|
+  loop do
+    length = file.read_byte
+    break if length.nil?
+
+    term = file.read_string(length)
+    file.read_byte # Null terminated
+
+    where = file.read_bytes(Int32)
+    size = file.read_bytes(Int32)
+
+    vocab[term] = {where, size}
+  rescue IO::EOFError
+    break
+  end
+end
+
+# Open the postings list file
+postings_fh = File.open("postings.bin")
+
+# Search (one query per line)
+loop do
+  query = gets
+  break if query.nil?
+
+  query = query.split
+
+  query_id = 0
+  accumulators = Array.new(doc_ids.size) { |i| {0.0, i} }
+
+  # If the first token is a number then assume a TREC query number, and skip it
+  begin
+    query_id = query[0].to_i
+    query.shift
+  rescue ArgumentError
+  end
+
+  query.each do |term|
+    offset, size = vocab[term]
+    next if offset.nil? # Does the term exist in the collection?
+
+    # Seek and read the postings list
+    postings = [] of Int32
+    postings_fh.read_at(offset, size) do |io|
+      loop do
+        postings << io.read_bytes(Int32)
+      rescue IO::EOFError
+        break
+      end
+    end
+
+    # Compute the IDF component of BM25 as log(N/n).
+    idf = Math.log(doc_ids.size.to_f / (postings.size / 2))
+
+    # Process the postings list by simply adding the BM25 component for this document into the accumulators array
+    postings.each_slice(2) do |pair|
+      docid, tf = pair
+      rsv = idf * ((tf * (k1 + 1)) / (tf + k1 * (1 - b + b * (doc_lengths[docid] / average_length))))
+      prev = accumulators[docid]
+      accumulators[docid] = {prev[0] + rsv, prev[1]}
+    end
+  end
+
+  # Sort the results list. Tie break on the document ID.
+  accumulators.sort!.reverse!
+
+  # Print the (at most) top 1000 documents in the results list in TREC eval format which is:
+  # query-id Q0 document-id rank score run-name
+  accumulators.take_while { |pair| pair[1] > 0 }.each_with_index do |(rsv, docid), i|
+    break if i == 1000
+    puts("#{query_id} Q0 #{doc_ids[docid]} #{i+1} #{"%.4f" % rsv} JASSjr")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ So JASSjr is not as fast as JASSv2, and not quite as good at ranking as JASSv2, 
 | JASSjr_search.d | D source code to search engine |
 | JASSjr_index.php | PHP source code to indexer |
 | JASSjr_search.php | PHP source code to search engine |
+| JASSjr_index.cr | Crystal source code to indexer |
+| JASSjr_search.cr | Crystal source code to search engine |
 | GNUmakefile | GNU make makefile for macOS / Linux |
 | makefile | NMAKE makefile for Windows |
 | test_documents.xml | Example of how documents should be layed out for indexing | 
@@ -188,6 +190,7 @@ These are for example purposes only. Each implementation is intending to be idio
 | Language | Version                   | Parser | Accumulators | Indexing | Search |
 | -------- | -------                   |------- | ------------ | -------- | ------ |
 | C++      | c++11/gcc 13.2            | Lexer  | Array        | 15s      | 280ms  |
+| Crystal  | 1.12.1/15.0.7             | Regex  | Array        | 29s      | 160ms  |
 | D (dmd)  | v2.101.1                  | Lexer  | Array        | 49s      | 250ms  |
 | D (ldc)  | 1.31.0/v2.101.2/15.0.7    | Lexer  | Array        | 30s      | 220ms  |
 | Elixir   | 1.15.7/erts-14.2.3        | Lexer  | HashMap      | 125s     | 850ms  |

--- a/tests/10_index.bats
+++ b/tests/10_index.bats
@@ -31,6 +31,10 @@ test_index_command() {
 	test_index_command ./JASSjr_index
 }
 
+@test "Crystal" {
+	test_index_command ./JASSjr_index.cr
+}
+
 @test "D (dmd)" {
 	test_index_command ./JASSjr_index_d_dmd
 }

--- a/tests/10_search.bats
+++ b/tests/10_search.bats
@@ -132,6 +132,10 @@ test_search_command() {
 	test_search_command ./JASSjr_search
 }
 
+@test "Crystal" {
+	test_search_command ./JASSjr_search.cr
+}
+
 @test "D (dmd)" {
 	test_search_command ./JASSjr_search_d_dmd
 }


### PR DESCRIPTION
Crystal is a language heavily inspired by Ruby but statically typed and compiled with some improvements to API consistency and error handling over Ruby

I have verified the indexer and search using the tools in the repo

Here are some timings against the baseline on my i7-7700k:
| | Time to index (s) | Time for one query (ms) | Time for 50 queries (ms) |
| - | - | - | - |
| C++ | 15 | 180 | 590 |
| Crystal | 29 | 160 | 820 |

I have recently upgraded my musl libc version from 1.1.24 to 1.2.5 which may account for the improvements in the C++ performance compared to the comparisons in older PRs. I plan to write a benchmark script and when I do I'll include updated timings in the README