### PR TITLE
JASSjr in Lua

### DIFF
--- a/JASSjr_index.lua
+++ b/JASSjr_index.lua
@@ -1,0 +1,130 @@
+#!/usr/bin/env luajit
+
+-- Copyright (c) 2024 Vaughan Kitchen
+-- Minimalistic BM25 search engine.
+
+-- Allow strings to be accessed like an array
+getmetatable('').__index = function(str, i) return string.sub(str, i, i) end
+-- Allow strings to be "called" to access substr
+getmetatable('').__call = string.sub
+
+-- Lua5.3 includes pack but we are targeting Lua5.1
+function pack_int(num)
+	return string.char(
+		bit.band(num, 0xFF),
+		bit.rshift(bit.band(num, 0xFF00), 8),
+		bit.rshift(bit.band(num, 0xFF0000), 16),
+		bit.rshift(bit.band(num, 0xFF000000), 24)
+	)
+end
+
+-- Make sure we have one parameter, the filename
+if #arg ~= 1 then
+	print(string.format("Usage: %s <infile.xml>", arg[0]))
+	os.exit()
+end
+
+local vocab = {} -- the in-memory index
+local doc_ids = {} -- the primary keys
+local doc_lengths = {} -- hold the length of each document
+
+local docid = -1
+local document_length = 0
+local push_next = false -- is the next token the primary key?
+
+local fh = assert(io.open(arg[1]))
+for line in fh:lines() do
+	-- A token is either an XML tag '<'..'>' or a sequence of alpha-numerics
+	-- TREC <DOCNO> primary keys have a hyphen in them
+	-- Lua patterns aren't full regex. We can't do alternation on groups
+	-- As our document is fairly well formed we should be fine
+	for token in string.gmatch(line, "<?/?[a-zA-Z0-9][a-zA-Z0-9-]*") do
+		-- If we see a <DOC> tag then we're at the start of the next document
+		if token == "<DOC" then
+			-- Save the previous document length
+			if docid ~= -1 then
+				table.insert(doc_lengths, document_length)
+			end
+			-- Move on to the next document
+			docid = docid + 1
+			document_length = 0
+			if docid % 1000 == 0 then
+				print(string.format("%d documents indexed", docid))
+			end
+		end
+		-- If the last token we saw was a <DOCNO> then the next token is the primary key
+		if push_next then
+			table.insert(doc_ids, token)
+			push_next = false
+		end
+		if token == "<DOCNO" then
+			push_next = true
+		end
+		-- Don't index XML tags
+		if token[1] ~= "<" then
+			-- TODO handle / at start of string
+			-- Lowercase the string
+			token = string.lower(token)
+
+			-- Truncate any long tokens at 255 characters (so that the length can be stored first and in a single byte)
+			token = token(1, 255)
+
+			-- Add the posting to the in-memory index
+			local postings = vocab[token] or {}
+			local postings_len = #postings -- TODO make this more efficient? (is O(log(n))
+			if postings_len == 0 or postings[postings_len - 1] ~= docid then
+				-- If the docno for this occurence has changed then create a new <d,tf> pair
+				table.insert(postings, docid)
+				table.insert(postings, 1)
+			else
+				postings[postings_len] = postings[postings_len] + 1
+			end
+			vocab[token] = postings
+
+			-- Compute the document length
+			document_length = document_length + 1
+		end
+	end
+end
+
+-- If we didn't index any documents then we're done
+if docid == -1 then
+	os.exit()
+end
+
+-- Save the final document length
+table.insert(doc_lengths, document_length)
+
+-- Tell the user we've got to the end of parsing
+print(string.format("Indexed %d documents. Serialising...", docid + 1))
+
+-- Store the primary keys
+local docids_fh = io.open("docids.bin", "w")
+for _, docid in ipairs(doc_ids) do
+	docids_fh:write(docid, "\n")
+end
+
+local postings_fh = io.open("postings.bin", "w")
+local vocab_fh = io.open("vocab.bin", "w")
+for term, postings in pairs(vocab) do
+	-- Write the postings list to one file
+	local where = postings_fh:seek()
+	for _, post in ipairs(postings) do
+		postings_fh:write(pack_int(post))
+	end
+
+	-- Write the vocabulary to a second file (one byte length, string, '\0', 4 byte where, 4 byte size)
+	vocab_fh:write(string.char(string.len(term)), term, "\0", pack_int(where), pack_int(#postings * 4))
+end
+
+-- Store the document lengths
+local lengths_fh = io.open("lengths.bin", "w")
+for _, length in ipairs(doc_lengths) do
+	lengths_fh:write(pack_int(length))
+end
+
+-- Clean up
+docids_fh:close()
+postings_fh:close()
+vocab_fh:close()
+lengths_fh:close()

--- a/JASSjr_index.lua
+++ b/JASSjr_index.lua
@@ -62,7 +62,10 @@ for line in fh:lines() do
 		end
 		-- Don't index XML tags
 		if token[1] ~= "<" then
-			-- TODO handle / at start of string
+			-- Due to lack of regex and needing to match closing tags, we pick up strings starting with /
+			if token[1] == "/" then
+				token = token(2)
+			end
 			-- Lowercase the string
 			token = string.lower(token)
 

--- a/JASSjr_search.lua
+++ b/JASSjr_search.lua
@@ -1,0 +1,160 @@
+#!/usr/bin/env luajit
+
+-- Copyright (c) 2024 Vaughan Kitchen
+-- Minimalistic BM25 search engine.
+
+-- Allow strings to be accessed like an array
+getmetatable('').__index = function(str, i) return string.sub(str, i, i) end
+-- Allow strings to be "called" to access substr
+getmetatable('').__call = string.sub
+
+-- Lua5.3 includes unpack but we are targeting Lua5.1
+function unpack_int(str)
+	return bit.bor(
+		string.byte(str[1]),
+		bit.lshift(string.byte(str[2]), 8),
+		bit.lshift(string.byte(str[3]), 16),
+		bit.lshift(string.byte(str[4]), 24)
+	)
+end
+
+local k1 = 0.9 -- BM25 k1 parameter
+local b = 0.4 -- BM25 b parameter
+
+local documents_in_collection = 0
+
+-- Read the primary keys
+local doc_ids = {}
+local doc_ids_fh = assert(io.open("docids.bin"), "r")
+for line in doc_ids_fh:lines() do
+	table.insert(doc_ids, line)
+	documents_in_collection = documents_in_collection + 1
+end
+
+-- Read the document lengths
+local doc_lengths = {}
+local doc_lengths_fh = assert(io.open("lengths.bin"), "rb")
+local doc_lengths_raw = doc_lengths_fh:read("*all")
+
+local offset = 1
+while offset < string.len(doc_lengths_raw) do
+	table.insert(doc_lengths, unpack_int(doc_lengths_raw(offset, offset + 3)))
+	offset = offset + 4
+end
+
+-- Compute the average document length for BM25
+local average_length = 0
+local count = 0
+for _, length in ipairs(doc_lengths) do
+	average_length = average_length + length
+	count = count + 1
+end
+average_length = average_length / count
+
+-- Decode the vocabulary (unsigned byte length, string, '\0', 4 byte signed where, 4 signed byte size)
+local vocab = {}
+local vocab_fh = assert(io.open("vocab.bin"), "rb")
+local vocab_raw = vocab_fh:read("*all")
+
+local offset = 1
+while offset < string.len(vocab_raw) do
+	length = string.byte(vocab_raw[offset])
+	offset = offset + 1
+
+	term = vocab_raw(offset, offset + length - 1)
+	offset = offset + length + 1
+
+	where = unpack_int(vocab_raw(offset, offset + 3))
+	offset = offset + 4
+	size = unpack_int(vocab_raw(offset, offset + 3))
+	offset = offset + 4
+
+	vocab[term] = {where, size}
+end
+
+-- Open the postings list file
+local postings_fh = assert(io.open("postings.bin"), "rb")
+
+-- Search (one query per line)
+while true do
+	local query = io.read()
+	if query == nil then
+		break
+	end
+
+	local accumulators = {}
+
+	local query_id = nil
+	local allow_search = false
+
+	for term in string.gmatch(query, "%S+") do
+		-- If the first token is a number then assume a TREC query number, and skip it
+		if not allow_search then
+			query_id = tonumber(term)
+			if query_id == nil then
+				query_id = 0
+				allow_search = true
+			end
+		end
+
+		if allow_search then
+			local pair = vocab[term]
+			-- Does the term exist in the collection?
+			if pair then
+				local offset = pair[1]
+				local size = pair[2]
+
+				-- Seek and read the postings list
+				local postings = {}
+
+				postings_fh:seek("set", offset)
+				local postings_raw = postings_fh:read(size)
+
+				local offset = 1
+				while offset < size do
+					table.insert(postings, unpack_int(postings_raw(offset, offset + 3)))
+					offset = offset + 4
+				end
+
+				-- Compute the IDF component of BM25 as log(N/n)
+				local idf = math.log(documents_in_collection / (size / 8))
+
+				-- Process the postings list by simply adding the BM25 component for this document into the accumulators array
+				local offset = 1
+				while offset < size / 4 do
+					local docid = postings[offset]
+					local tf = postings[offset+1]
+
+					local rsv = idf * tf * (k1 + 1) / (tf + k1 * (1 - b + b * (doc_lengths[docid+1] / average_length)))
+
+					local current_rsv = accumulators[docid] or 0
+					accumulators[docid] = current_rsv + rsv
+
+					offset = offset + 2
+				end
+			end
+		end
+
+		allow_search = true
+	end
+
+	-- Turn the accumulators back into an array to get a stable ordering
+	local results = {}
+	for docid, rsv in pairs(accumulators) do
+		table.insert(results, {rsv, docid})
+	end
+
+	-- Sort the results list. Tie break on the document ID
+	table.sort(results, function(a, b) return a[1] == b[1] and a[2] > b[2] or a[1] > b[1] end)
+
+	-- Print the (at most) top 1000 documents in the results list in TREC eval format which is:
+	-- query-id Q0 document-id rank score run-name
+	for i, pair in ipairs(results) do
+		if i > 1000 then
+			break
+		end
+		local rsv = pair[1]
+		local docid = pair[2]
+		print(string.format("%d Q0 %s %d %.4f JASSjr", query_id, doc_ids[docid+1], i, rsv))
+	end
+end

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ So JASSjr is not as fast as JASSv2, and not quite as good at ranking as JASSv2, 
 | JASSjr_search.php | PHP source code to search engine |
 | JASSjr_index.cr | Crystal source code to indexer |
 | JASSjr_search.cr | Crystal source code to search engine |
+| JASSjr_index.lua | Lua source code to indexer |
+| JASSjr_search.lua | Lua source code to search engine |
 | GNUmakefile | GNU make makefile for macOS / Linux |
 | makefile | NMAKE makefile for Windows |
 | test_documents.xml | Example of how documents should be layed out for indexing | 
@@ -198,12 +200,13 @@ These are for example purposes only. Each implementation is intending to be idio
 | Go       | 1.22.0                    | Lexer  | Array        | 18.42s   | 220ms   | 680ms     |
 | Java     | 1.8.0_332                 | Lexer  | Array        | 17.97s   | 320ms   | 1.18s     |
 | JS       | node v18.19.1             | Regex  | Array        | 34.37s   | 750ms   | 3.78s     |
+| Lua      | LuaJIT 2.1.0-beta3        | Regex  | HashMap      | 63.75s   | 360ms   | 1.19s     |
 | Nim      | 2.0.0                     | Regex  | Array        | 19.07s   | 350ms   | 1.09s     |
 | Perl     | v5.38.2                   | Regex  | Array        | 117.78s  | 950ms   | 3.63s     |
 | PHP      | 8.3.0/Zend v4.3.0         | Regex  | HashMap      | 29.50s   | 350ms   | 830ms     |
 | Python   | 3.12.2                    | Regex  | Array        | 76.30s   | 830ms   | 2.84s     |
 | Raku     | v6.d/2023.11              | Regex  | Array        | 140min?? | 8.07s   | 173.40s   |
-| Ruby     | 3.3.2                     | Regex  | Array        | 156.45s  | 1.16s   | 4.73s     |
+| Ruby     | 3.3.2                     | Regex  | HashMap      | 156.45s  | 1.16s   | 4.73s     |
 | Zig      | 0.12.0                    | Lexer  | Array        | 8.60s    | 80ms    | 490ms     |
 
 Times are recorded as median of 11 iterations and ?? are times which haven't been confirmed by `/tools/benchmark.sh`

--- a/tests/10_index.bats
+++ b/tests/10_index.bats
@@ -63,6 +63,10 @@ test_index_command() {
 	test_index_command ./JASSjr_index.js
 }
 
+@test "Lua" {
+	test_index_command ./JASSjr_index.lua
+}
+
 @test "Nim" {
 	test_index_command ./JASSjr_index.nim
 }

--- a/tests/10_search.bats
+++ b/tests/10_search.bats
@@ -1,5 +1,9 @@
 #!/usr/bin/env bats
 
+zero=`cat << EOF
+0 Q0 0 1 2.7475 JASSjr
+EOF`
+
 one=`cat << EOF
 0 Q0 10 1 2.0802 JASSjr
 EOF`
@@ -97,6 +101,9 @@ setup() {
 test_search_command() {
 	command="$1"
 
+	run $command <<< zero
+	assert_output "$zero"
+
 	run $command <<< one
 	assert_output "$one"
 
@@ -162,6 +169,10 @@ test_search_command() {
 
 @test "JavaScript" {
 	test_search_command ./JASSjr_search.js
+}
+
+@test "Lua" {
+	test_search_command ./JASSjr_search.lua
 }
 
 @test "Nim" {


### PR DESCRIPTION
Lua is a lightweight language useful for embedding. Luajit is a JIT compiler for Lua 5.1 commonly used where performance matters such as in LÖVE a Lua game engine

I have verified the indexer and search using the tools in the repo. Timings are included in the README

I got caught by the 1 indexing in Lua and have added the "zero" test to `10_search.bats`

I also noticed the Ruby change from Array to HashMap accumulators in the README got lost when I rebased last night. I have included it here rather than open another PR