### PR TITLE
Speed up Go indexer a bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.mod
 *.bin
 *~
+
+# Compiled binaries.
+/JASSjr_index
+/JASSjr_search

--- a/JASSjr_search.go
+++ b/JASSjr_search.go
@@ -103,13 +103,9 @@ func main() {
 	}
 
 	/*
-	  Allocate buffers
+	  Allocate buffers and set up the rsv pointers
 	*/
-	rsv := make([]float64, documentsInCollection) // array of rsv values
-
-	/*
-	  Set up the rsv pointers
-	*/
+	rsv := make([]float64, documentsInCollection)     // array of rsv values
 	rsvPointers := make([]int, documentsInCollection) // pointers to each member of rsv[] so that we can sort
 
 	/*
@@ -126,7 +122,7 @@ func main() {
 			rsv[i] = 0
 			rsvPointers[i] = len(rsvPointers) - 1 - i
 		}
-		var queryId int = 0
+		queryId := 0
 		for i, token := range strings.Fields(stdin.Text()) {
 			/*
 			  If the first token is a number then assume a TREC query number, and skip it

--- a/tools/benchmark.sh
+++ b/tools/benchmark.sh
@@ -32,10 +32,10 @@ done
 timings=$(echo -n "$timings" | sort -n)
 fastest=$(echo -n "$timings" | head -n 1)
 slowest=$(echo -n "$timings" | tail -n 1)
-midpoint=$(echo "($iters + 1) / 2" | bc)
+midpoint=$(( ($iters + 1) / 2 ))
 median=$(echo -n "$timings" | head -n "$midpoint" | tail -n 1)
 
 echo
 echo "Fastest: $fastest"
 echo "Slowest: $slowest"
-echo "Median: $median"
+echo "Median:  $median"


### PR DESCRIPTION
Just returning byte slice is a lot faster than returning a pointer to a string. Also pre-allocate some arrays, to avoid needless allocations on appends.

With:

	./tools/benchmark.sh 11 ./JASSjr_index wsj.xml

Before:

	Fastest: 24.25
	Slowest: 26.96
	Median:  24.59

After:

	Fastest: 20.42
	Slowest: 22.85
	Median:  21.01