### PR TITLE
Benchmark script portability

### DIFF
--- a/tools/benchmark.sh
+++ b/tools/benchmark.sh
@@ -24,8 +24,8 @@ echo "Warmup"
 timings=''
 for i in $(seq 1 "$iters"); do
 	echo "Iteration $i"
-	# Use GNU time
-	seconds=$( { echo "$in" | /usr/bin/time "$@" > /dev/null ; } 2>&1 | awk '{ print $1 '})
+	# Use system time command instead of shell builtin
+	seconds=$( { echo "$in" | /usr/bin/time -p "$@" > /dev/null ; } 2>&1 | head -n 1 | cut -d' ' -f2 )
 	timings="$timings$seconds
 "
 done

--- a/tools/benchmark.sh
+++ b/tools/benchmark.sh
@@ -25,8 +25,9 @@ timings=''
 for i in $(seq 1 "$iters"); do
 	echo "Iteration $i"
 	# Use GNU time
-	seconds=$( { echo "$in" | /usr/bin/time -f '%e' "$@" > /dev/null ; } 2>&1)
-	timings="$timings$seconds\n"
+	seconds=$( { echo "$in" | /usr/bin/time "$@" > /dev/null ; } 2>&1 | awk '{ print $1 '})
+	timings="$timings$seconds
+"
 done
 
 timings=$(echo -n "$timings" | sort -n)


### PR DESCRIPTION
Fixes some portability bugs between different versions of time and echo

GNU time supports -f but BSD time does not. To ensure consistent format from time we now specify POSIX mode with -p and process the text output ourselves

Some versions of echo process backslash escape codes e.g. \n by default but some do not. I didn't manage to discover which ones do and do not but have hit inconsistency between different Linux distros. Instead of an escape we now include a literal newline in the string