### PR TITLE
Go: Slice literal for new postings

### DIFF
--- a/JASSjr_index.go
+++ b/JASSjr_index.go
@@ -170,9 +170,7 @@ func main() {
 			*/
 			list, ok := vocab[token]
 			if !ok { // term isn't in the vocab yet
-				newList := make([]posting, 0, 4)
-				newList = append(newList, posting{docId, 1})
-				vocab[token] = newList
+				vocab[token] = []posting{{docId, 1}}
 			} else if list[len(list)-1].d != docId {
 				vocab[token] = append(list, posting{docId, 1}) // if the docno for this occurence has changed then create a new <d,tf> pair
 			} else {


### PR DESCRIPTION
Simplifies the expression for creating a new postings list. This suggestion came from @arp242 though I'm not sure why he didn't include it in his PR

I have found no performance regressions with this change